### PR TITLE
docs: add DISCLAIMER and NOTICE

### DIFF
--- a/DISCLAIMER
+++ b/DISCLAIMER
@@ -1,0 +1,5 @@
+Apache Casbin (Incubating) is an effort undergoing incubation at the Apache Software Foundation (ASF), sponsored by the Apache Incubator PMC.
+
+Incubation is required of all newly accepted projects until a further review indicates that the infrastructure, communications, and decision making process have stabilized in a manner consistent with other successful ASF projects.
+
+While incubation status is not necessarily a reflection of the completeness or stability of the code, it does indicate that the project has yet to be fully endorsed by the ASF.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,8 @@
+Apache Casbin (Incubating)
+Copyright 2026 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (https://www.apache.org/).
+
+Portions of this software were originally developed by the Casbin project.
+Copyright 2022-2026 The casbin Authors.


### PR DESCRIPTION
## Why

The repo root lacks the compliance files required for an incubating Apache project.

## Changes

- Add `DISCLAIMER` (verbatim-identical to already-compliant repos like casbin/pycasbin/casbin-mongodb-adapter, CRLF line endings)
- Add `NOTICE` (first copyright year 2022 = the repo's earliest commit year; CRLF line endings)

## Verification

DISCLAIMER byte-compared to casbin-pycasbin after normalizing line endings — identical; both files use CRLF to match the ecosystem.