### PR TITLE
docs: rename CasWAF to casbin-gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<h1 align="center" style="border-bottom: none;">📦⚡️ CasWAF</h1>
+<h1 align="center" style="border-bottom: none;">📦⚡️ casbin-gateway</h1>
 <h3 align="center">An open-source Web Application Firewall (WAF) software developed by Go and React.</h3>
 <p align="center">
   <a href="#badge">
@@ -44,20 +44,20 @@ https://caswaf.org
 
 ## Architecture
 
-CasWAF contains 2 parts:
+casbin-gateway contains 2 parts:
 
 | Name     | Description                    | Language               | Source code                                      |
 |----------|--------------------------------|------------------------|--------------------------------------------------|
-| Frontend | Web frontend UI for CasWAF     | Javascript + React     | https://github.com/casbin/caswaf/tree/master/web |
-| Backend  | RESTful API backend for CAsWAF | Golang + Beego + MySQL | https://github.com/casbin/caswaf                 |
+| Frontend | Web frontend UI for casbin-gateway     | Javascript + React     | https://github.com/casbin/caswaf/tree/master/web |
+| Backend  | RESTful API backend for casbin-gateway | Golang + Beego + MySQL | https://github.com/casbin/caswaf                 |
 
 ## Installation
 
-CasWAF uses Casdoor to manage members. So you need to create an organization and an application for CasWAF in a Casdoor instance.
+casbin-gateway uses Casdoor to manage members. So you need to create an organization and an application for casbin-gateway in a Casdoor instance.
 
 ### Deployment Options
 
-- **[Kubernetes Deployment](k8s/README.md)**: Deploy CasWAF on Kubernetes with complete manifests and guide
+- **[Kubernetes Deployment](k8s/README.md)**: Deploy casbin-gateway on Kubernetes with complete manifests and guide
 - **Docker Compose**: Use the provided `docker-compose.yml` for quick local setup
 - **Manual Installation**: Build and run from source
 
@@ -79,36 +79,36 @@ git clone https://github.com/casbin/caswaf
 
 #### Setup database
 
-CasWAF will store its users, nodes and topics information in a MySQL database named: `caswaf`, will create it if not existed. The DB connection string can be specified at: https://github.com/casbin/caswaf/blob/master/conf/app.conf
+casbin-gateway will store its users, nodes and topics information in a MySQL database named: `caswaf`, will create it if not existed. The DB connection string can be specified at: https://github.com/casbin/caswaf/blob/master/conf/app.conf
 
 ```ini
 dataSourceName = root:123@tcp(localhost:3306)/
 ```
 
-CasWAF uses XORM to connect to DB, so all DBs supported by XORM can also be used.
+casbin-gateway uses XORM to connect to DB, so all DBs supported by XORM can also be used.
 
 #### Configure Casdoor
 
-After creating an organization and an application for CasWAF in a Casdoor, you need to update `clientID`, `clientSecret`, `casdoorOrganization` and `casdoorApplication` in app.conf.
+After creating an organization and an application for casbin-gateway in a Casdoor, you need to update `clientID`, `clientSecret`, `casdoorOrganization` and `casdoorApplication` in app.conf.
 
-#### Run CasWAF
+#### Run casbin-gateway
 
-- Configure and run CasWAF by yourself. If you want to learn more about caswaf.
+- Configure and run casbin-gateway by yourself. If you want to learn more about caswaf.
 - Open browser: http://localhost:16001/
 
 ### Optional configuration
 
 #### Setup your WAF to enable some third-party login platform
 
-CasWAF uses Casdoor to manage members. If you want to log in with oauth, you should see [casdoor oauth configuration](https://casdoor.org/docs/provider/oauth/overview).
+casbin-gateway uses Casdoor to manage members. If you want to log in with oauth, you should see [casdoor oauth configuration](https://casdoor.org/docs/provider/oauth/overview).
 
 #### OSS, Mail, and SMS services
 
-CasWAF uses Casdoor to upload files to cloud storage, send Emails and send SMSs. See Casdoor for more details.
+casbin-gateway uses Casdoor to upload files to cloud storage, send Emails and send SMSs. See Casdoor for more details.
 
 ## Contribute
 
-For CasWAF, if you have any questions, you can open Issues, or you can also directly start Pull Requests(but we recommend opening issues first to communicate with the community).
+For casbin-gateway, if you have any questions, you can open Issues, or you can also directly start Pull Requests(but we recommend opening issues first to communicate with the community).
 
 ## License
 

--- a/k8s/.env.example
+++ b/k8s/.env.example
@@ -1,4 +1,4 @@
-# Example configuration for CasWAF Kubernetes deployment
+# Example configuration for casbin-gateway Kubernetes deployment
 # Copy this file and modify for your environment
 
 # MySQL Configuration
@@ -14,7 +14,7 @@ CASDOOR_ORGANIZATION=built-in
 CASDOOR_APPLICATION=app-casdoor-gateway
 CASDOOR_INSECURE_SKIP_VERIFY=true
 
-# CasWAF Configuration
+# casbin-gateway Configuration
 CASWAF_HTTP_PORT=17000
 CASWAF_RUN_MODE=prod
 

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -1,6 +1,6 @@
-# Kubernetes Deployment Guide for CasWAF
+# Kubernetes Deployment Guide for casbin-gateway
 
-This guide provides instructions for deploying CasWAF on Kubernetes.
+This guide provides instructions for deploying casbin-gateway on Kubernetes.
 
 ## Prerequisites
 
@@ -12,18 +12,18 @@ This guide provides instructions for deploying CasWAF on Kubernetes.
 ## Architecture
 
 The deployment consists of:
-- **CasWAF Application**: The main WAF application
-- **MySQL Database**: Stores CasWAF configuration and data
+- **casbin-gateway Application**: The main WAF application
+- **MySQL Database**: Stores casbin-gateway configuration and data
 - **Secrets**: Stores sensitive credentials (Casdoor client ID/secret, MySQL password)
-- **ConfigMap**: Contains CasWAF configuration template
-- **Services**: Exposes CasWAF and MySQL within the cluster
-- **Ingress** (optional): Exposes CasWAF externally
+- **ConfigMap**: Contains casbin-gateway configuration template
+- **Services**: Exposes casbin-gateway and MySQL within the cluster
+- **Ingress** (optional): Exposes casbin-gateway externally
 
 ## Quick Start
 
 ### 1. Deploy Casdoor (if not already deployed)
 
-CasWAF requires Casdoor for authentication. If you don't have Casdoor deployed:
+casbin-gateway requires Casdoor for authentication. If you don't have Casdoor deployed:
 
 ```bash
 # Follow Casdoor's Kubernetes deployment guide:
@@ -76,7 +76,7 @@ casdoorEndpoint: http://your-casdoor-service:port
 
 **Option A: Using the deployment script (Recommended)**
 
-The easiest way to deploy CasWAF:
+The easiest way to deploy casbin-gateway:
 
 ```bash
 cd k8s
@@ -88,7 +88,7 @@ The script will:
 - Validate your configuration
 - Deploy MySQL and wait for it to be ready
 - Deploy secrets and configuration
-- Deploy CasWAF application
+- Deploy casbin-gateway application
 - Optionally deploy Ingress
 - Show deployment status
 
@@ -107,7 +107,7 @@ kubectl apply -f k8s/secret.yaml
 # Deploy ConfigMap
 kubectl apply -f k8s/configmap.yaml
 
-# Deploy CasWAF
+# Deploy casbin-gateway
 kubectl apply -f k8s/deployment.yaml
 
 # (Optional) Deploy Ingress
@@ -132,7 +132,7 @@ kubectl logs -f deployment/caswaf -n caswaf
 kubectl get svc -n caswaf
 ```
 
-### 7. Access CasWAF
+### 7. Access casbin-gateway
 
 If using Ingress:
 ```bash
@@ -163,7 +163,7 @@ Key configuration parameters:
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| `httpport` | CasWAF HTTP port | `17000` |
+| `httpport` | casbin-gateway HTTP port | `17000` |
 | `runmode` | Run mode (dev/prod) | `prod` |
 | `driverName` | Database driver | `mysql` |
 | `dataSourceName` | MySQL connection string | Uses secrets substitution |
@@ -182,7 +182,7 @@ Key configuration parameters:
 - Includes health checks (liveness and readiness probes)
 - Root password stored in Kubernetes Secret with obvious placeholder
 
-### CasWAF Deployment (`deployment.yaml`)
+### casbin-gateway Deployment (`deployment.yaml`)
 
 Features:
 - Init containers:
@@ -238,7 +238,7 @@ kubectl get svc -n caswaf caswaf-mysql
 
 **Solution**:
 ```bash
-# Test MySQL connection from CasWAF pod
+# Test MySQL connection from casbin-gateway pod
 kubectl exec -it deployment/caswaf -n caswaf -- sh
 # Then inside the pod:
 # nc -zv caswaf-mysql 3306
@@ -258,7 +258,7 @@ kubectl rollout restart deployment/caswaf -n caswaf
 ### Viewing Logs
 
 ```bash
-# CasWAF logs
+# casbin-gateway logs
 kubectl logs -f deployment/caswaf -n caswaf
 
 # MySQL logs
@@ -288,7 +288,7 @@ kubectl logs -f -n caswaf --all-containers=true
    ```
 
 4. **High Availability**:
-   - Increase replicas for CasWAF
+   - Increase replicas for casbin-gateway
    - Use MySQL replication or managed service
    - Configure proper health checks
 
@@ -305,7 +305,7 @@ kubectl logs -f -n caswaf --all-containers=true
    - Network policies to restrict traffic
    - Regular security updates
 
-## Updating CasWAF
+## Updating casbin-gateway
 
 ```bash
 # Update the image version in deployment.yaml, then:

--- a/k8s/deploy.sh
+++ b/k8s/deploy.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-# Quick deployment script for CasWAF on Kubernetes
-# This script helps you deploy CasWAF with proper configuration
+# Quick deployment script for casbin-gateway on Kubernetes
+# This script helps you deploy casbin-gateway with proper configuration
 # Usage: ./deploy.sh [--auto-ingress|--no-ingress]
 
 set -euo pipefail
@@ -31,7 +31,7 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-echo -e "${GREEN}CasWAF Kubernetes Deployment Script${NC}"
+echo -e "${GREEN}casbin-gateway Kubernetes Deployment Script${NC}"
 echo "====================================="
 echo
 
@@ -84,21 +84,21 @@ kubectl wait --for=condition=ready pod -l app=caswaf-mysql -n caswaf --timeout=3
 echo -e "${GREEN}✓ MySQL is ready${NC}"
 echo
 
-echo -e "${YELLOW}Step 3: Deploying CasWAF configuration...${NC}"
+echo -e "${YELLOW}Step 3: Deploying casbin-gateway configuration...${NC}"
 kubectl apply -f secret.yaml
 kubectl apply -f configmap.yaml
 echo -e "${GREEN}✓ Configuration deployed${NC}"
 echo
 
-echo -e "${YELLOW}Step 4: Deploying CasWAF application...${NC}"
+echo -e "${YELLOW}Step 4: Deploying casbin-gateway application...${NC}"
 kubectl apply -f deployment.yaml
 
-echo "Waiting for CasWAF to be ready..."
+echo "Waiting for casbin-gateway to be ready..."
 kubectl wait --for=condition=ready pod -l app=caswaf -n caswaf --timeout=300s || {
-    echo -e "${RED}Warning: CasWAF took longer than expected to start${NC}"
+    echo -e "${RED}Warning: casbin-gateway took longer than expected to start${NC}"
     echo "Check logs with: kubectl logs -n caswaf -l app=caswaf"
 }
-echo -e "${GREEN}✓ CasWAF is deployed${NC}"
+echo -e "${GREEN}✓ casbin-gateway is deployed${NC}"
 echo
 
 # Handle Ingress deployment
@@ -127,7 +127,7 @@ if [ "$AUTO_INGRESS" = "yes" ]; then
 else
     echo -e "${YELLOW}Skipping Ingress deployment${NC}"
     echo
-    echo "You can access CasWAF using port-forward:"
+    echo "You can access casbin-gateway using port-forward:"
     echo "  kubectl port-forward svc/caswaf 17000:17000 -n caswaf"
     echo "  Then access: http://localhost:17000"
 fi
@@ -138,7 +138,7 @@ echo "==================="
 kubectl get all -n caswaf
 
 echo
-echo -e "${GREEN}✓ CasWAF deployment completed successfully!${NC}"
+echo -e "${GREEN}✓ casbin-gateway deployment completed successfully!${NC}"
 echo
 echo "Useful commands:"
 echo "  View pods:        kubectl get pods -n caswaf"

--- a/object/site_timer_health.go
+++ b/object/site_timer_health.go
@@ -51,7 +51,7 @@ func healthCheck(site *Site, domain string) error {
 		return nil
 	}
 
-	pingResponse = fmt.Sprintf("CasWAF health check failed for domain %s, %s", domain, pingResponse)
+	pingResponse = fmt.Sprintf("casbin-gateway health check failed for domain %s, %s", domain, pingResponse)
 	user, err := casdoorsdk.GetUser(site.Owner)
 	if err != nil {
 		return err
@@ -61,7 +61,7 @@ func healthCheck(site *Site, domain string) error {
 	}
 	for _, provider := range site.AlertProviders {
 		if strings.HasPrefix(provider, "Email/") {
-			err := casdoorsdk.SendEmailByProvider("CasWAF HealthCheck Check Alert", pingResponse, "CasWAF", provider[6:], user.Email)
+			err := casdoorsdk.SendEmailByProvider("casbin-gateway HealthCheck Check Alert", pingResponse, "casbin-gateway", provider[6:], user.Email)
 			if err != nil {
 				fmt.Println(err)
 			}

--- a/service/oauth.go
+++ b/service/oauth.go
@@ -40,29 +40,29 @@ func redirectToCasdoor(casdoorClient *casdoorsdk.Client, w http.ResponseWriter, 
 func handleAuthCallback(w http.ResponseWriter, r *http.Request) {
 	site := getSiteByDomainWithWww(r.Host)
 	if site == nil {
-		responseError(w, "CasWAF error: site not found for host: %s", r.Host)
+		responseError(w, "casbin-gateway error: site not found for host: %s", r.Host)
 		return
 	}
 
 	code := r.URL.Query().Get("code")
 	state := r.URL.Query().Get("state")
 	if code == "" {
-		responseError(w, "CasWAF error: the code should not be empty")
+		responseError(w, "casbin-gateway error: the code should not be empty")
 		return
 	} else if state == "" {
-		responseError(w, "CasWAF error: the state should not be empty")
+		responseError(w, "casbin-gateway error: the state should not be empty")
 		return
 	}
 
 	casdoorClient, err := getCasdoorClientFromSite(site)
 	if err != nil {
-		responseError(w, "CasWAF error: getCasdoorClientFromSite() error: %s", err.Error())
+		responseError(w, "casbin-gateway error: getCasdoorClientFromSite() error: %s", err.Error())
 		return
 	}
 
 	token, err := casdoorClient.GetOAuthToken(code, state)
 	if err != nil {
-		responseError(w, "CasWAF error: casdoorClient.GetOAuthToken() error: %s", err.Error())
+		responseError(w, "casbin-gateway error: casdoorClient.GetOAuthToken() error: %s", err.Error())
 		return
 	}
 

--- a/service/proxy.go
+++ b/service/proxy.go
@@ -169,7 +169,7 @@ func handleRequest(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		responseError(w, "CasWAF error: site not found for host: %s", r.Host)
+		responseError(w, "casbin-gateway error: site not found for host: %s", r.Host)
 		return
 	}
 
@@ -187,7 +187,7 @@ func handleRequest(w http.ResponseWriter, r *http.Request) {
 	if site.Node == "" {
 		site.Node = util.GetHostname()
 		_, err := object.UpdateSiteNoRefresh(site.GetId(), site)
-		responseError(w, "CasWAF error: UpdateSiteNoRefresh() error: %v", err)
+		responseError(w, "casbin-gateway error: UpdateSiteNoRefresh() error: %v", err)
 		return
 	}
 
@@ -200,7 +200,7 @@ func handleRequest(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
-		responseError(w, fmt.Sprintf("CasWAF error: ACME HTTP-01 challenge failed, requestUri cannot match with challengeMap, requestUri = %s, challengeMap = %v", r.RequestURI, challengeMap))
+		responseError(w, fmt.Sprintf("casbin-gateway error: ACME HTTP-01 challenge failed, requestUri cannot match with challengeMap, requestUri = %s, challengeMap = %v", r.RequestURI, challengeMap))
 		return
 	}
 
@@ -232,7 +232,7 @@ func handleRequest(w http.ResponseWriter, r *http.Request) {
 
 		casdoorClient, err := getCasdoorClientFromSite(site)
 		if err != nil {
-			responseError(w, "CasWAF error: getCasdoorClientFromSite() error: %s", err.Error())
+			responseError(w, "casbin-gateway error: getCasdoorClientFromSite() error: %s", err.Error())
 			return
 		}
 
@@ -243,7 +243,7 @@ func handleRequest(w http.ResponseWriter, r *http.Request) {
 		} else {
 			_, err = casdoorClient.ParseJwtToken(cookie.Value)
 			if err != nil {
-				responseError(w, "CasWAF error: casdoorClient.ParseJwtToken() error: %s", err.Error())
+				responseError(w, "casbin-gateway error: casdoorClient.ParseJwtToken() error: %s", err.Error())
 				return
 			}
 		}
@@ -251,7 +251,7 @@ func handleRequest(w http.ResponseWriter, r *http.Request) {
 
 	host := site.GetHost()
 	if host == "" {
-		responseError(w, "CasWAF error: targetUrl should not be empty for host: %s, site = %v", r.Host, site)
+		responseError(w, "casbin-gateway error: targetUrl should not be empty for host: %s, site = %v", r.Host, site)
 		return
 	}
 
@@ -276,11 +276,11 @@ func handleRequest(w http.ResponseWriter, r *http.Request) {
 		// Do not write header for Allow action, let the proxy handle it
 	case "Block":
 		w.WriteHeader(result.StatusCode)
-		responseErrorWithoutCode(w, "Blocked by CasWAF: %s", reason)
+		responseErrorWithoutCode(w, "Blocked by casbin-gateway: %s", reason)
 		return
 	case "Drop":
 		w.WriteHeader(result.StatusCode)
-		responseErrorWithoutCode(w, "Dropped by CasWAF: %s", reason)
+		responseErrorWithoutCode(w, "Dropped by casbin-gateway: %s", reason)
 		return
 	case "CAPTCHA":
 		ok := isVerifiedSession(r)
@@ -293,7 +293,7 @@ func handleRequest(w http.ResponseWriter, r *http.Request) {
 		redirectToCaptcha(w, r)
 		return
 	default:
-		responseError(w, "Error in CasWAF: %s", reason)
+		responseError(w, "Error in casbin-gateway: %s", reason)
 	}
 	nextHandle(w, r)
 }
@@ -332,7 +332,7 @@ func Start() {
 		panic(err)
 	}
 	if !gatewayEnabled {
-		fmt.Printf("CasWAF gateway not enabled (gatewayEnabled == \"false\")\n")
+		fmt.Printf("casbin-gateway gateway not enabled (gatewayEnabled == \"false\")\n")
 		return
 	}
 
@@ -347,7 +347,7 @@ func Start() {
 	}
 
 	go func() {
-		fmt.Printf("CasWAF gateway running on: http://127.0.0.1:%d\n", gatewayHttpPort)
+		fmt.Printf("casbin-gateway gateway running on: http://127.0.0.1:%d\n", gatewayHttpPort)
 		err := http.ListenAndServe(fmt.Sprintf(":%d", gatewayHttpPort), serverMux)
 		if err != nil {
 			panic(err)
@@ -355,7 +355,7 @@ func Start() {
 	}()
 
 	go func() {
-		fmt.Printf("CasWAF gateway running on: https://127.0.0.1:%d\n", gatewayHttpsPort)
+		fmt.Printf("casbin-gateway gateway running on: https://127.0.0.1:%d\n", gatewayHttpsPort)
 		server := &http.Server{
 			Handler: serverMux,
 			Addr:    fmt.Sprintf(":%d", gatewayHttpsPort),

--- a/util/supervisor.go
+++ b/util/supervisor.go
@@ -56,7 +56,7 @@ func InitSelfGuard() {
 
 // runSupervisor starts the supervisor that monitors and restarts the main process
 func runSupervisor() error {
-	fmt.Println("Starting CasWAF with auto-recovery mechanism...")
+	fmt.Println("Starting casbin-gateway with auto-recovery mechanism...")
 	
 	restartTimes := []time.Time{}
 	

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>CasWAF</title>
+    <title>casbin-gateway</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/web/public/manifest.json
+++ b/web/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "CasWAF",
-  "name": "CasWAF",
+  "short_name": "casbin-gateway",
+  "name": "casbin-gateway",
   "icons": [
     {
       "src": "favicon.ico",

--- a/web/src/BaseListPage.js
+++ b/web/src/BaseListPage.js
@@ -1,4 +1,4 @@
-// Copyright 2024 The CasWAF Authors. All Rights Reserved.
+// Copyright 2024 The casbin-gateway Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Why

The repo has been renamed to casbin-gateway, but the display name in code and docs still uses the old name CasWAF, so UI text, document titles, error messages and email alerts are inconsistent.

## Changes

Replace the display name `CasWAF` with `casbin-gateway` in 11 files (70 occurrences in total, including 1 case typo `CAsWAF`):

- README.md (title, body, descriptions)
- k8s/README.md, k8s/.env.example, k8s/deploy.sh (Kubernetes deployment docs and script output)
- object/site_timer_health.go (health-check email alert text)
- service/oauth.go, service/proxy.go (error message text)
- util/supervisor.go (startup log)
- web/public/index.html, web/public/manifest.json, web/src/BaseListPage.js (frontend title and app name)

Not changed: Go module path `github.com/casbin/caswaf`, database name `caswaf`, domains (caswaf.org / demo.caswaf.com / door.caswaf.com) and other lowercase caswaf references — minimal change scope.

## Verification

`go build ./...` passes; no `CasWAF` residue in the repo; only display-name/text strings were replaced, no logic changes.