### PR TITLE
feat: add channel model and CRUD API

### DIFF
--- a/controllers/channel.go
+++ b/controllers/channel.go
@@ -1,0 +1,147 @@
+// Copyright 2026 The casbin Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllers
+
+import (
+	"encoding/json"
+
+	"github.com/beego/beego/utils/pagination"
+	"github.com/casbin/caswaf/object"
+	"github.com/casbin/caswaf/util"
+)
+
+func (c *ApiController) GetGlobalChannels() {
+	if c.RequireSignedIn() {
+		return
+	}
+
+	channels, err := object.GetGlobalChannels()
+	if err != nil {
+		c.ResponseError(err.Error())
+		return
+	}
+
+	c.ResponseOk(object.GetMaskedChannels(channels))
+}
+
+func (c *ApiController) GetChannels() {
+	if c.RequireSignedIn() {
+		return
+	}
+
+	owner := c.Input().Get("owner")
+	if owner == "admin" {
+		owner = ""
+	}
+
+	limit := c.Input().Get("pageSize")
+	page := c.Input().Get("p")
+	field := c.Input().Get("field")
+	value := c.Input().Get("value")
+	sortField := c.Input().Get("sortField")
+	sortOrder := c.Input().Get("sortOrder")
+
+	if limit == "" || page == "" {
+		channels, err := object.GetChannels(owner)
+		if err != nil {
+			c.ResponseError(err.Error())
+			return
+		}
+		c.ResponseOk(object.GetMaskedChannels(channels))
+		return
+	}
+
+	limitInt := util.ParseInt(limit)
+	count, err := object.GetChannelCount(owner, field, value)
+	if err != nil {
+		c.ResponseError(err.Error())
+		return
+	}
+
+	paginator := pagination.SetPaginator(c.Ctx, limitInt, count)
+	channels, err := object.GetPaginationChannels(owner, paginator.Offset(), limitInt, field, value, sortField, sortOrder)
+	if err != nil {
+		c.ResponseError(err.Error())
+		return
+	}
+
+	c.ResponseOk(object.GetMaskedChannels(channels), paginator.Nums())
+}
+
+func (c *ApiController) GetChannel() {
+	if c.RequireSignedIn() {
+		return
+	}
+
+	id := c.Input().Get("id")
+
+	channel, err := object.GetChannel(id)
+	if err != nil {
+		c.ResponseError(err.Error())
+		return
+	}
+
+	c.ResponseOk(object.GetMaskedChannel(channel))
+}
+
+func (c *ApiController) UpdateChannel() {
+	if c.RequireSignedIn() {
+		return
+	}
+
+	id := c.Input().Get("id")
+
+	var channel object.Channel
+	err := json.Unmarshal(c.Ctx.Input.RequestBody, &channel)
+	if err != nil {
+		c.ResponseError(err.Error())
+		return
+	}
+
+	c.Data["json"] = wrapActionResponse(object.UpdateChannel(id, &channel))
+	c.ServeJSON()
+}
+
+func (c *ApiController) AddChannel() {
+	if c.RequireSignedIn() {
+		return
+	}
+
+	var channel object.Channel
+	err := json.Unmarshal(c.Ctx.Input.RequestBody, &channel)
+	if err != nil {
+		c.ResponseError(err.Error())
+		return
+	}
+
+	c.Data["json"] = wrapActionResponse(object.AddChannel(&channel))
+	c.ServeJSON()
+}
+
+func (c *ApiController) DeleteChannel() {
+	if c.RequireSignedIn() {
+		return
+	}
+
+	var channel object.Channel
+	err := json.Unmarshal(c.Ctx.Input.RequestBody, &channel)
+	if err != nil {
+		c.ResponseError(err.Error())
+		return
+	}
+
+	c.Data["json"] = wrapActionResponse(object.DeleteChannel(&channel))
+	c.ServeJSON()
+}

--- a/object/channel.go
+++ b/object/channel.go
@@ -1,0 +1,172 @@
+// Copyright 2026 The casbin Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package object
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/casbin/caswaf/util"
+	"github.com/xorm-io/core"
+)
+
+// Channel is an upstream LLM service configuration (e.g. OpenAI, DeepSeek, Anthropic).
+// Type is a free-form string by convention: openai / anthropic / deepseek / custom.
+type Channel struct {
+	Owner       string `xorm:"varchar(100) notnull pk" json:"owner"`
+	Name        string `xorm:"varchar(100) notnull pk" json:"name"`
+	CreatedTime string `xorm:"varchar(100)" json:"createdTime"`
+	UpdatedTime string `xorm:"varchar(100)" json:"updatedTime"`
+	DisplayName string `xorm:"varchar(100)" json:"displayName"`
+
+	Type      string   `xorm:"varchar(100)" json:"type"`
+	BaseURL   string   `xorm:"varchar(200) 'base_url'" json:"baseUrl"`
+	SecretKey string   `xorm:"varchar(500)" json:"secretKey"`
+	Models    []string `xorm:"varchar(1000)" json:"models"`
+	Status    string   `xorm:"varchar(100)" json:"status"`
+}
+
+func GetGlobalChannels() ([]*Channel, error) {
+	channels := []*Channel{}
+	err := ormer.Engine.Desc("created_time").Find(&channels)
+	if err != nil {
+		return nil, err
+	}
+
+	return channels, nil
+}
+
+func GetChannels(owner string) ([]*Channel, error) {
+	channels := []*Channel{}
+	err := ormer.Engine.Asc("created_time").Find(&channels, &Channel{Owner: owner})
+	if err != nil {
+		return nil, err
+	}
+
+	return channels, nil
+}
+
+func getChannel(owner string, name string) (*Channel, error) {
+	channel := Channel{Owner: owner, Name: name}
+	existed, err := ormer.Engine.Get(&channel)
+	if err != nil {
+		return nil, err
+	}
+
+	if existed {
+		return &channel, nil
+	}
+	return nil, nil
+}
+
+func GetChannel(id string) (*Channel, error) {
+	owner, name := util.GetOwnerAndNameFromId(id)
+	channel, err := getChannel(owner, name)
+	if err != nil {
+		return nil, err
+	}
+
+	return channel, nil
+}
+
+func UpdateChannel(id string, channel *Channel) (bool, error) {
+	owner, name := util.GetOwnerAndNameFromId(id)
+	if c, err := getChannel(owner, name); err != nil {
+		return false, err
+	} else if c == nil {
+		return false, nil
+	}
+
+	channel.UpdatedTime = util.GetCurrentTime()
+
+	session := ormer.Engine.ID(core.PK{owner, name})
+	if channel.SecretKey == "" || strings.Contains(channel.SecretKey, "****") {
+		// The secret key was returned masked (or left empty) by the frontend:
+		// keep the stored key untouched instead of overwriting it with the masked value.
+		_, err := session.Omit("secret_key").AllCols().Update(channel)
+		if err != nil {
+			return false, err
+		}
+	} else {
+		_, err := session.AllCols().Update(channel)
+		if err != nil {
+			return false, err
+		}
+	}
+
+	return true, nil
+}
+
+func AddChannel(channel *Channel) (bool, error) {
+	affected, err := ormer.Engine.Insert(channel)
+	if err != nil {
+		return false, err
+	}
+
+	return affected != 0, nil
+}
+
+func DeleteChannel(channel *Channel) (bool, error) {
+	affected, err := ormer.Engine.ID(core.PK{channel.Owner, channel.Name}).Delete(&Channel{})
+	if err != nil {
+		return false, err
+	}
+
+	return affected != 0, nil
+}
+
+func (channel *Channel) GetId() string {
+	return fmt.Sprintf("%s/%s", channel.Owner, channel.Name)
+}
+
+func maskSecretKey(secretKey string) string {
+	if len(secretKey) <= 8 {
+		return "****"
+	}
+
+	return fmt.Sprintf("%s****%s", secretKey[:4], secretKey[len(secretKey)-4:])
+}
+
+func GetMaskedChannel(channel *Channel) *Channel {
+	if channel == nil {
+		return nil
+	}
+
+	channel.SecretKey = maskSecretKey(channel.SecretKey)
+	return channel
+}
+
+func GetMaskedChannels(channels []*Channel) []*Channel {
+	for _, channel := range channels {
+		channel = GetMaskedChannel(channel)
+	}
+	return channels
+}
+
+func GetChannelCount(owner, field, value string) (int64, error) {
+	session := GetSession(owner, -1, -1, field, value, "", "")
+	return session.Count(&Channel{})
+}
+
+func GetPaginationChannels(owner string, offset, limit int, field, value, sortField, sortOrder string) ([]*Channel, error) {
+	channels := []*Channel{}
+	session := GetSession(owner, offset, limit, field, value, sortField, sortOrder)
+	err := session.Where("owner = ? or owner = ?", "admin", owner).Find(&channels)
+	if err != nil {
+		return channels, err
+	}
+
+	return channels, nil
+}

--- a/object/ormer.go
+++ b/object/ormer.go
@@ -189,6 +189,11 @@ func (a *Ormer) createTable() {
 		panic(err)
 	}
 
+	err = a.Engine.Sync2(new(Channel))
+	if err != nil {
+		panic(err)
+	}
+
 	err = a.Engine.Sync2(new(Cert))
 	if err != nil {
 		panic(err)

--- a/routers/router.go
+++ b/routers/router.go
@@ -51,6 +51,13 @@ func initAPI() {
 	beego.Router("/api/add-site", &controllers.ApiController{}, "POST:AddSite")
 	beego.Router("/api/delete-site", &controllers.ApiController{}, "POST:DeleteSite")
 
+	beego.Router("/api/get-global-channels", &controllers.ApiController{}, "GET:GetGlobalChannels")
+	beego.Router("/api/get-channels", &controllers.ApiController{}, "GET:GetChannels")
+	beego.Router("/api/get-channel", &controllers.ApiController{}, "GET:GetChannel")
+	beego.Router("/api/update-channel", &controllers.ApiController{}, "POST:UpdateChannel")
+	beego.Router("/api/add-channel", &controllers.ApiController{}, "POST:AddChannel")
+	beego.Router("/api/delete-channel", &controllers.ApiController{}, "POST:DeleteChannel")
+
 	beego.Router("/api/get-global-certs", &controllers.ApiController{}, "GET:GetGlobalCerts")
 	beego.Router("/api/get-certs", &controllers.ApiController{}, "GET:GetCerts")
 	beego.Router("/api/get-cert", &controllers.ApiController{}, "GET:GetCert")


### PR DESCRIPTION

# Why

- CasWAF is being transformed into a UI-first LLM API security gateway (issue #179). The gateway needs a place where users can configure upstream LLM services (e.g. OpenAI, DeepSeek, Anthropic) before the unified entry (/v1/chat/completions), token authentication, rate limiting and logging can be built on top.
- Subtask 1.1 introduces the Channel entity — one upstream LLM service configuration (base URL, secret key, supported models, status) — with a data model and a full CRUD API, following the existing object/site.go pattern in this repo.
- This is the foundation for the following subtasks: routing (1.2), token authentication (1.3), logs (1.4) and the frontend pages (1.5).

# What changed

- object/channel.go (new): Channel data model (owner/name composite primary key, timestamps, type, baseUrl, secretKey, models, status) and CRUD functions: GetGlobalChannels, GetChannels, GetChannel, AddChannel, UpdateChannel, DeleteChannel, plus pagination helpers GetChannelCount / GetPaginationChannels.
- Secret key masking: GetMaskedChannel / GetMaskedChannels mask the secret key (e.g. sk-a****-777) before returning it to the frontend, following the existing GetMaskedSite pattern.
- Update safety: UpdateChannel skips the secret_key column when the incoming value is empty or masked (contains ****), so a masked value returned by the frontend can never overwrite the real key in the database.
- controllers/channel.go (new): six API handler methods (GetGlobalChannels, GetChannels, GetChannel, AddChannel, UpdateChannel, DeleteChannel), each guarded by RequireSignedIn().
- routers/router.go: register six routes: /api/get-global-channels, /api/get-channels, /api/get-channel, /api/add-channel, /api/update-channel, /api/delete-channel.
- object/ormer.go: register the Channel table via Sync2 in createTable() so it is auto-created at startup.

# Verification

- go build ./... passes (go 1.20.14, module keeps go 1.16).
- go vet ./object/ ./controllers/ ./routers/ reports zero warnings.
- Data-layer unit test passes: add → get (raw key) → mask → update with masked key (real key preserved) → update with new key (key updated) → list → delete.
- Live API test against a running server (http://:17000) passes for all six endpoints: add 4 channels, list shows 3 with masked keys (sk-o****-111), single get, update with masked key (HEX check confirms the real key sk-openai-real-key-111 is NOT overwritten), delete works.
- The channel table is auto-created by Sync2 with the correct base_url column name.