### PR TITLE
test: make object tests self-contained with fixtures and skip manual ops

### DIFF
--- a/object/cert_test.go
+++ b/object/cert_test.go
@@ -18,146 +18,72 @@
 package object
 
 import (
-	"fmt"
 	"testing"
-
-	"github.com/apache/casbin-gateway/casdoor"
-	"github.com/apache/casbin-gateway/proxy"
-	"github.com/apache/casbin-gateway/util"
+	"time"
 )
 
 func TestGetCertExpireTime(t *testing.T) {
-	InitConfig()
+	certPem, notAfter := generateTestCertPem(t)
+	createTestCert(t, "casbin.com", certPem)
 
-	cert, err := getCert("admin", "casbin.com")
+	cert, err := getCert(testOwner, "casbin.com")
 	if err != nil {
-		panic(err)
+		t.Fatalf("getCert() error: %v", err)
+	}
+	if cert == nil {
+		t.Fatalf("cert should not be nil")
 	}
 
 	expireTime, err := getCertExpireTime(cert.Certificate)
 	if err != nil {
-		panic(err)
+		t.Fatalf("getCertExpireTime() error: %v", err)
 	}
 
-	println(expireTime)
+	expected := notAfter.Truncate(time.Second)
+	actual, err := time.Parse(time.RFC3339, expireTime)
+	if err != nil {
+		t.Fatalf("failed to parse expire time %q: %v", expireTime, err)
+	}
+	if !actual.Equal(expected) {
+		t.Fatalf("expire time = %s, want %s", actual.Format(time.RFC3339), expected.Format(time.RFC3339))
+	}
 }
 
+// TestRenewCert renews a real certificate via an external provider, which is a
+// manual operation and is skipped in automated test runs.
 func TestRenewCert(t *testing.T) {
-	InitConfig()
-	proxy.InitHttpClient()
-
-	cert, err := GetCert("admin/cert")
-	if err != nil {
-		panic(err)
-	}
-
-	res, err := RenewCert(cert)
-	if err != nil {
-		panic(err)
-	}
-
-	fmt.Printf("Renewed cert: [%s] to [%s], res = %v\n", cert.Name, cert.ExpireTime, res)
+	t.Skip("renews a real certificate via an external provider, run manually with real data")
 }
 
+// TestRenewAllCerts renews real certificates via external providers, which is
+// a manual operation and is skipped in automated test runs.
 func TestRenewAllCerts(t *testing.T) {
-	InitConfig()
-	proxy.InitHttpClient()
-
-	certs, err := GetCerts("admin")
-	if err != nil {
-		panic(err)
-	}
-
-	filteredCerts := []*Cert{}
-	for _, cert := range certs {
-		if cert.Owner != "admin" || cert.Provider == "" {
-			continue
-		}
-
-		if cert.Provider == "GoDaddy" {
-			continue
-		}
-
-		var nearExpire bool
-		nearExpire, err = cert.isCertNearExpire()
-		if err != nil {
-			panic(err)
-		}
-		if !nearExpire {
-			continue
-		}
-
-		filteredCerts = append(filteredCerts, cert)
-	}
-
-	for i, cert := range filteredCerts {
-		if cert.Owner != "admin" || cert.Provider == "" {
-			continue
-		}
-
-		if cert.Provider == "GoDaddy" {
-			continue
-		}
-
-		var nearExpire bool
-		nearExpire, err = cert.isCertNearExpire()
-		if err != nil {
-			panic(err)
-		}
-		if !nearExpire {
-			continue
-		}
-
-		var res bool
-		res, err = RenewCert(cert)
-		if err != nil {
-			panic(err)
-		}
-
-		fmt.Printf("[%d/%d] Renewed cert: [%s] to [%s], res = %v\n", i+1, len(filteredCerts), cert.Name, cert.ExpireTime, res)
-	}
+	t.Skip("renews real certificates via external providers, run manually with real data")
 }
 
-func TestApplyAllCerts(t *testing.T) {
-	InitConfig()
-
-	baseDir := "F:/github_repos/nginx/conf/ssl"
-	certs, err := GetCerts("admin")
-	if err != nil {
-		panic(err)
-	}
-
-	for _, cert := range certs {
-		if cert.Certificate == "" || cert.PrivateKey == "" {
-			continue
-		}
-
-		util.WriteStringToPath(cert.Certificate, fmt.Sprintf("%s/%s.pem", baseDir, cert.Name))
-		util.WriteStringToPath(cert.PrivateKey, fmt.Sprintf("%s/%s.key", baseDir, cert.Name))
-	}
-}
-
-func TestCheckCerts(t *testing.T) {
-	InitConfig()
-	casdoor.InitCasdoorConfig()
-	proxy.InitHttpClient()
+// TestCheckCertsNoOpForEmptyNodes covers the no-op path of checkCerts() for
+// a site fixture with no nodes and no tag: getNodeNameFromTag("") returns ""
+// which never equals the real hostname, so checkCerts() returns nil before
+// the domain loop runs. The test therefore really verifies getCertMap() and
+// getSite() plus that early return, not any certificate processing.
+func TestCheckCertsNoOpForEmptyNodes(t *testing.T) {
+	createTestSite(t, "test-site")
 
 	var err error
 	certMap, err = getCertMap()
 	if err != nil {
-		panic(err)
+		t.Fatalf("getCertMap() error: %v", err)
 	}
 
-	site, err := getSite("admin", "test-site")
+	site, err := getSite(testOwner, "test-site")
 	if err != nil {
-		panic(err)
+		t.Fatalf("getSite() error: %v", err)
 	}
 	if site == nil {
-		panic("site should not be nil")
+		t.Fatalf("site should not be nil")
 	}
 
-	err = site.checkCerts()
-	if err != nil {
-		panic(err)
+	if err = site.checkCerts(); err != nil {
+		t.Fatalf("checkCerts() error: %v", err)
 	}
 }

--- a/object/cert_whois_test.go
+++ b/object/cert_whois_test.go
@@ -18,35 +18,11 @@
 package object
 
 import (
-	"fmt"
 	"testing"
 )
 
+// TestUpdateDomainExpireTime performs real WHOIS lookups against external
+// services, which is a manual operation and is skipped in automated test runs.
 func TestUpdateDomainExpireTime(t *testing.T) {
-	InitConfig()
-
-	certs, err := GetCerts("admin")
-	if err != nil {
-		panic(err)
-	}
-
-	for i, cert := range certs {
-		certExpireTime, err := getDomainExpireTime(cert.Name)
-		if err != nil {
-			panic(err)
-		}
-
-		if cert.DomainExpireTime == certExpireTime {
-			continue
-		}
-
-		cert.DomainExpireTime = certExpireTime
-
-		res, err := UpdateCert(cert.GetId(), cert)
-		if err != nil {
-			panic(err)
-		}
-
-		fmt.Printf("[%d/%d] Refreshed cert [%s]'s domain expire time: [%s], res = %v\n", i+1, len(certs), cert.Name, cert.DomainExpireTime, res)
-	}
+	t.Skip("performs real WHOIS lookups against external services, run manually with real data")
 }

--- a/object/main_test.go
+++ b/object/main_test.go
@@ -1,0 +1,157 @@
+// Copyright 2026 The casbin Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !skipCi
+// +build !skipCi
+
+package object
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/apache/casbin-gateway/casdoor"
+	"github.com/apache/casbin-gateway/proxy"
+	"github.com/apache/casbin-gateway/util"
+)
+
+// testOwner is a dedicated owner used by test fixtures, so that the tests
+// never touch data of real users (e.g. "admin" or the developer's own account).
+const testOwner = "caswaf-test"
+
+func TestMain(m *testing.M) {
+	InitConfig()
+	casdoor.InitCasdoorConfig()
+	proxy.InitHttpClient()
+
+	os.Exit(m.Run())
+}
+
+// generateTestCertPem generates a self-signed certificate that is valid for
+// 100 years and returns its PEM text together with its NotAfter time. The
+// certificate is generated on the fly at test runtime, so no certificate
+// material is hardcoded in the repository.
+func generateTestCertPem(t *testing.T) (string, time.Time) {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate test certificate key: %v", err)
+	}
+
+	notBefore := time.Now().Add(-24 * time.Hour)
+	notAfter := time.Now().Add(36500 * 24 * time.Hour)
+
+	template := x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "caswaf-test"},
+		NotBefore:             notBefore,
+		NotAfter:              notAfter,
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, &template, &template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("failed to create test certificate: %v", err)
+	}
+
+	return string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})), notAfter
+}
+
+// createTestSite inserts a site fixture under the dedicated test owner and
+// registers a cleanup that deletes it when the test finishes (no matter
+// whether it passed, failed or panicked). If a site with the same id already
+// exists, the test is skipped to avoid touching real data.
+func createTestSite(t *testing.T, name string) *Site {
+	t.Helper()
+
+	existing, err := getSite(testOwner, name)
+	if err != nil {
+		t.Fatalf("getSite() error: %v", err)
+	}
+	if existing != nil {
+		t.Skipf("site %s/%s already exists in the database, skip to avoid touching existing data", testOwner, name)
+	}
+
+	site := &Site{
+		Owner:          testOwner,
+		Name:           name,
+		CreatedTime:    util.GetCurrentTime(),
+		OtherDomains:   []string{},
+		Rules:          []string{},
+		AlertProviders: []string{},
+		Challenges:     []string{},
+		Hosts:          []string{},
+		Nodes:          []*NodeItem{},
+	}
+
+	_, err = AddSite(site)
+	if err != nil {
+		t.Fatalf("AddSite() error: %v", err)
+	}
+
+	t.Cleanup(func() {
+		if _, err := DeleteSite(site); err != nil {
+			t.Errorf("DeleteSite() cleanup error: %v", err)
+		}
+	})
+
+	return site
+}
+
+// createTestCert inserts a cert fixture under the dedicated test owner and
+// registers a cleanup that deletes it when the test finishes. If a cert with
+// the same id already exists, the test is skipped to avoid touching real data.
+func createTestCert(t *testing.T, name string, certificate string) *Cert {
+	t.Helper()
+
+	existing, err := getCert(testOwner, name)
+	if err != nil {
+		t.Fatalf("getCert() error: %v", err)
+	}
+	if existing != nil {
+		t.Skipf("cert %s/%s already exists in the database, skip to avoid touching existing data", testOwner, name)
+	}
+
+	cert := &Cert{
+		Owner:       testOwner,
+		Name:        name,
+		CreatedTime: util.GetCurrentTime(),
+		Type:        "Manual",
+		Certificate: certificate,
+	}
+
+	_, err = AddCert(cert)
+	if err != nil {
+		t.Fatalf("AddCert() error: %v", err)
+	}
+
+	t.Cleanup(func() {
+		if _, err := DeleteCert(cert); err != nil {
+			t.Errorf("DeleteCert() cleanup error: %v", err)
+		}
+	})
+
+	return cert
+}

--- a/object/site_test.go
+++ b/object/site_test.go
@@ -19,40 +19,49 @@ package object
 
 import (
 	"testing"
-
-	"github.com/apache/casbin-gateway/casdoor"
 )
 
-func TestCheckNode(t *testing.T) {
-	InitConfig()
-	casdoor.InitCasdoorConfig()
+// TestUpdateSiteStatus verifies that UpdateSite persists a status change
+// ("Inactive") for a site fixture. Note: the createTestSite fixture has no
+// nodes, so the checkNodes() call above only exercises the empty-node path
+// and none of its ping/process side effects are executed.
+func TestUpdateSiteStatus(t *testing.T) {
+	createTestSite(t, "caswaf_my")
 
-	site, err := getSite("admin", "caswaf_my")
+	site, err := getSite(testOwner, "caswaf_my")
 	if err != nil {
-		panic(err)
+		t.Fatalf("getSite() error: %v", err)
 	}
 	if site == nil {
-		panic("site should not be nil")
+		t.Fatalf("site should not be nil")
 	}
 
 	site.Status = "Active"
-	err = site.checkNodes()
-	if err != nil {
-		panic(err)
+	if err = site.checkNodes(); err != nil {
+		t.Fatalf("checkNodes() error: %v", err)
 	}
 
-	site, err = getSite("admin", "caswaf_my")
+	site, err = getSite(testOwner, "caswaf_my")
 	if err != nil {
-		panic(err)
+		t.Fatalf("getSite() error: %v", err)
 	}
 	if site == nil {
-		panic("site should not be nil")
+		t.Fatalf("site should not be nil")
 	}
 
 	site.Status = "Inactive"
+	if _, err = UpdateSite(site.GetId(), site); err != nil {
+		t.Fatalf("UpdateSite() error: %v", err)
+	}
 
-	_, err = UpdateSite(site.GetId(), site)
+	updated, err := getSite(testOwner, "caswaf_my")
 	if err != nil {
-		panic(err)
+		t.Fatalf("getSite() error: %v", err)
+	}
+	if updated == nil {
+		t.Fatalf("site should not be nil")
+	}
+	if updated.Status != "Inactive" {
+		t.Fatalf("expected site status to be \"Inactive\", got %q", updated.Status)
 	}
 }


### PR DESCRIPTION
# Why

The tests under `object/` hardcode data of the original developer's account (`owner = "admin"`, e.g. sites `caswaf_my` / `test-site` and certs `casbin.com` / `admin/cert`). This data does not exist on any fresh database, so `go test ./object/...` always fails with a nil pointer panic. The tests are also excluded from CI (the `!skipCi` build tag plus the commented-out test step in `build.yml`), so the failure is invisible there, but every local run still breaks.

# What changed

- Added `object/main_test.go` with `TestMain` and fixtures: sites/certs are created under a dedicated owner `caswaf-test` and are automatically deleted when a test finishes (whether it passes, fails or panics). Existing data with the same id is never touched (the test skips instead).
- Reworked `TestGetCertExpireTime` into a real test: it generates a self-signed certificate at runtime (no hardcoded PEM), asserts the parsed expire time and cleans up the fixture cert.
- Renamed `TestCheckNode` to `TestUpdateSiteStatus` and `TestCheckCerts` to `TestCheckCertsNoOpForEmptyNodes`, with comments explaining what they actually cover (the no-node early-return path; the node health-check and cert renewal logic that has external side effects is intentionally not exercised).
- Removed `TestApplyAllCerts` (it wrote certificates to a machine-specific `F:/` nginx directory).
- Converted the remaining manual operations (`TestRenewCert`, `TestRenewAllCerts`, `TestUpdateDomainExpireTime`), which renew real certificates via external providers or perform real WHOIS lookups, to explicit `t.Skip` entries that can still be run manually.
- Replaced all `panic()` calls in the tests with `t.Fatalf()`.

# Verification

Local run on Windows (Go 1.20.14, MySQL):

`go test ./object/... -count=1 -v`

```
--- PASS: TestGetCertExpireTime (0.01s)
--- SKIP: TestRenewCert (0.00s)
--- SKIP: TestRenewAllCerts (0.00s)
--- PASS: TestCheckCertsNoOpForEmptyNodes (0.07s)
--- SKIP: TestUpdateDomainExpireTime (0.00s)
--- PASS: TestUpdateSiteStatus (0.09s)
PASS
ok  	github.com/apache/casbin-gateway/object	2.328s
```

After the run, no fixture data remains in the database:

```sql
SELECT COUNT(*) FROM site WHERE owner='caswaf-test';  -- 0
SELECT COUNT(*) FROM cert WHERE owner='caswaf-test';  -- 0
```