### PR TITLE
fix: normalize the /v1 prefix when building upstream urls

### DIFF
--- a/controllers/proxy.go
+++ b/controllers/proxy.go
@@ -170,8 +170,9 @@ func (c *ApiController) ChatCompletions() {
 // the next channel. The response of the last channel is always relayed, even
 // when its status would otherwise be retried.
 func (c *ApiController) forwardToChannel(channel *object.Channel, rawBody []byte, stream bool, isLast bool) (int, string, bool) {
-	// The path is hardcoded to the OpenAI-compatible /v1/chat/completions.
-	upstreamUrl := strings.TrimRight(channel.BaseUrl, "/") + "/v1/chat/completions"
+	// The endpoint is built through object.BuildOpenAiUrl, which normalizes
+	// base URLs that already carry the /v1 prefix so it is never doubled.
+	upstreamUrl := object.BuildOpenAiUrl(channel.BaseUrl, "/chat/completions")
 
 	// The context is cancelled when this function returns, which happens only
 	// after the response body has been relayed to the client.

--- a/controllers/proxy_test.go
+++ b/controllers/proxy_test.go
@@ -258,3 +258,23 @@ func TestForwardToChannel(t *testing.T) {
 		t.Errorf("Content-Type = %s, expected application/json", header)
 	}
 }
+
+// A base URL carrying the /v1 prefix (the form suggested by the web UI
+// presets) must not produce a doubled /v1/v1 path upstream.
+func TestForwardToChannelWithV1BaseUrl(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/chat/completions" {
+			t.Errorf("upstream path = %s, the /v1 prefix was doubled", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"choices":[]}`))
+	}))
+	defer upstream.Close()
+
+	channel := &object.Channel{Owner: "admin", Name: "v1", Type: "openai", BaseUrl: upstream.URL + "/v1", ApiKey: "sk-v1"}
+	c, recorder := newTestApiController()
+	_, _, written := c.forwardToChannel(channel, []byte(`{"model":"gpt-4"}`), false, true)
+	if !written || recorder.Code != http.StatusOK {
+		t.Errorf("forwarding failed: written = %v, statusCode = %d, body = %s", written, recorder.Code, recorder.Body.String())
+	}
+}

--- a/object/channel.go
+++ b/object/channel.go
@@ -202,6 +202,34 @@ func validateBaseUrl(baseUrl string) error {
 	return nil
 }
 
+// BuildOpenAiUrl joins an OpenAI-compatible endpoint onto a channel base URL.
+//
+// Base URLs may be configured either bare ("https://api.openai.com") or with
+// the standard /v1 prefix ("https://api.openai.com/v1", the form used by the
+// web UI presets and most upstream docs). Both forms are normalized here so
+// the endpoint is never doubled, and trailing slashes are tolerated. A
+// subpath ending in /v1, as used by some API gateways, is recognized as well.
+// endpoint must start with "/" and omit the /v1 prefix, e.g.
+// "/chat/completions" or "/models".
+//
+// Every OpenAI-compatible upstream URL must be built through this function,
+// so future endpoints inherit the same normalization.
+func BuildOpenAiUrl(baseUrl, endpoint string) string {
+	u, err := url.Parse(baseUrl)
+	if err != nil {
+		return ""
+	}
+	u.Path = strings.TrimRight(u.Path, "/")
+	if u.Path == "" {
+		u.Path = "/v1"
+	} else if !strings.HasSuffix(u.Path, "/v1") {
+		u.Path += "/v1"
+	}
+	u.Path += endpoint
+	u.RawPath = ""
+	return u.String()
+}
+
 func AddChannel(channel *Channel) (bool, error) {
 	if err := validateChannel(channel); err != nil {
 		return false, err
@@ -275,7 +303,7 @@ func TestChannelConnectivity(channel *Channel) (bool, int, string) {
 
 	probeUrl := strings.TrimRight(stored.BaseUrl, "/")
 	if stored.Type == "openai" {
-		probeUrl += "/v1/models"
+		probeUrl = BuildOpenAiUrl(stored.BaseUrl, "/models")
 	}
 
 	req, err := http.NewRequest(http.MethodGet, probeUrl, nil)

--- a/object/channel_test.go
+++ b/object/channel_test.go
@@ -1,0 +1,40 @@
+// Copyright 2023 The casbin Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package object
+
+import "testing"
+
+func TestBuildOpenAiUrl(t *testing.T) {
+	cases := []struct {
+		name     string
+		baseUrl  string
+		endpoint string
+		expected string
+	}{
+		{"bare host", "https://api.openai.com", "/chat/completions", "https://api.openai.com/v1/chat/completions"},
+		{"bare host with trailing slash", "https://api.openai.com/", "/chat/completions", "https://api.openai.com/v1/chat/completions"},
+		{"with /v1 prefix", "https://api.openai.com/v1", "/chat/completions", "https://api.openai.com/v1/chat/completions"},
+		{"with /v1 prefix and trailing slash", "https://api.openai.com/v1/", "/chat/completions", "https://api.openai.com/v1/chat/completions"},
+		{"subpath ending in /v1", "https://oneapi.example.com/api/v1", "/chat/completions", "https://oneapi.example.com/api/v1/chat/completions"},
+		{"non-v1 subpath is not mistaken for /v1", "https://x.com/api/v1beta", "/chat/completions", "https://x.com/api/v1beta/v1/chat/completions"},
+		{"endpoint parameterization", "https://api.openai.com", "/models", "https://api.openai.com/v1/models"},
+	}
+
+	for _, tc := range cases {
+		if got := BuildOpenAiUrl(tc.baseUrl, tc.endpoint); got != tc.expected {
+			t.Errorf("%s: BuildOpenAiUrl(%q, %q) = %q, expected %q", tc.name, tc.baseUrl, tc.endpoint, got, tc.expected)
+		}
+	}
+}


### PR DESCRIPTION
# Why

A channel whose base URL carries the standard /v1 prefix (the exact form suggested by the web UI presets and most upstream docs, e.g. https://api.openai.com/v1) was broken: controllers/proxy.go unconditionally appended /v1/chat/completions to the base URL, producing a doubled path like https://api.openai.com/v1/v1/chat/completions that the upstream answers with 404. The openai connectivity probe had the same flaw (/v1/v1/models).

# What changed

- object/channel.go: added BuildOpenAiUrl(baseUrl, endpoint), which normalizes the base URL before appending the endpoint. Bare hosts, /v1-suffixed base URLs (with or without a trailing slash) and subpaths ending in /v1 are all accepted; the endpoint is never doubled. The openai connectivity probe now builds its /models URL through this function.
- controllers/proxy.go: the upstream chat completions URL is now built with object.BuildOpenAiUrl(channel.BaseUrl, "/chat/completions") instead of string concatenation.
- Tests: table-driven unit tests covering seven base URL shapes (object/channel_test.go) and an end-to-end forwarding test with a /v1-prefixed base URL (controllers/proxy_test.go).

# Verification

- go build ./... passes.
- go test ./object/ -run TestBuildOpenAiUrl -v passes (7 cases).
- go test ./controllers/ -run TestForwardToChannel -v passes, including the new TestForwardToChannelWithV1BaseUrl.
- Live end-to-end test against a real upstream: a channel with base URL https://api.openai.com/v1   passes Test Connection, and POST /v1/chat/completions returns a normal completion response instead of the previous upstream 404.