### PR TITLE
fix: use SQLite as the default database

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,24 +13,14 @@ jobs:
   go-tests:
     name: Running Go tests
     runs-on: ubuntu-latest
-    services:
-      mysql:
-        image: mysql:5.7
-        env:
-          MYSQL_DATABASE: casdoor
-          MYSQL_ROOT_PASSWORD: 123456
-        ports:
-          - 3306:3306
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.20.0'
+          go-version-file: go.mod
           cache-dependency-path: ./go.mod
       - name: Tests
-        run: |
-        # go test -v $(go list ./...) -tags skipCi
+        run: go test -v -tags skipCi ./agent ./controllers ./object ./rule
         working-directory: ./
 
   frontend:
@@ -55,7 +45,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.20.0'
+          go-version-file: go.mod
           cache-dependency-path: ./go.mod
       - run: go version
       - name: Build

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ tmpFiles/
 *.tmp
 logs/
 data/agent-patches/
+data/*.db
+data/*.db-shm
+data/*.db-wal
 lastupdate.tmp
 commentsRouter*.go
 acme_account.key

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,15 +6,12 @@ RUN yarn install --frozen-lockfile --network-timeout 1000000 && yarn run build
 FROM golang:1.20.12 AS BACK
 WORKDIR /go/src/caswaf
 COPY . .
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o server . \
-    && apt update && apt install wait-for-it && chmod +x /usr/bin/wait-for-it
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o server .
 
 FROM alpine:latest AS STANDARD
 LABEL MAINTAINER="https://caswaf.org/"
 
 COPY --from=BACK /go/src/caswaf/ ./
-COPY --from=BACK /usr/bin/wait-for-it ./
-RUN mkdir -p web/build && apk add --no-cache bash coreutils tzdata
+RUN mkdir -p web/build /data && apk add --no-cache tzdata
 COPY --from=FRONT /web/build /web/build
-ENTRYPOINT ["./wait-for-it", "db:3306", "--", "./server"]
-
+ENTRYPOINT ["./server"]

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Casbin Gateway contains 2 parts:
 | Name     | Description                            | Language               | Source code                                              |
 |----------|----------------------------------------|------------------------|----------------------------------------------------------|
 | Frontend | Web frontend UI for Casbin Gateway     | Javascript + React     | https://github.com/apache/casbin-gateway/tree/master/web |
-| Backend  | RESTful API backend for Casbin Gateway | Golang + Beego + MySQL | https://github.com/apache/casbin-gateway                 |
+| Backend  | RESTful API backend for Casbin Gateway | Golang + Beego + SQLite | https://github.com/apache/casbin-gateway                |
 
 ## Installation
 
@@ -67,15 +67,9 @@ The reverse-proxy gateway on ports 80 and 443 is disabled by default, so startin
 
 From nothing to a request flowing through the gateway, in five steps.
 
-#### 1. Start MySQL
+#### 1. Use the default SQLite database
 
-Any MySQL 5.7+ reachable from Gateway will do. With Docker:
-
-```bash
-docker run -d --name caswaf-db -p 3306:3306 -e MYSQL_ROOT_PASSWORD=123 mysql:8.0.25
-```
-
-Gateway creates the `caswaf` database itself on first start. If your MySQL is elsewhere, or the password is not `123`, change `dataSourceName` in `conf/app.conf`.
+No database setup is required. Gateway creates `data/casbin-gateway.db` automatically on first start. MySQL and PostgreSQL remain available as optional external databases through `conf/app.conf`.
 
 #### 2. Build the web UI
 
@@ -104,7 +98,7 @@ It prints a summary of what it is actually doing — ports, whether the reverse 
 | Reverse proxy  | enabled                                                    |
 | Gateway HTTP   | :8080                                                      |
 | Gateway HTTPS  | :8443                                                      |
-| Database       | mysql, database "caswaf" (connected)                       |
+| Database       | sqlite, file "data/casbin-gateway.db" (connected)           |
 | Sign-in        | built-in user table, Casdoor is not configured             |
 | App dir        | ./data/apps                                                |
 +----------------+-----------------------------------------------------------+
@@ -156,13 +150,17 @@ git clone https://github.com/apache/casbin-gateway
 
 #### Setup database
 
-Casbin Gateway will store its users, nodes and topics information in a MySQL database named: `caswaf`, will create it if not existed. The DB connection string can be specified at: https://github.com/apache/casbin-gateway/blob/master/conf/app.conf
+Casbin Gateway uses SQLite by default and creates `data/casbin-gateway.db` automatically. No separate database service is required for native, Docker Compose, or Kubernetes deployments.
 
 ```ini
-dataSourceName = root:123@tcp(localhost:3306)/
+driverName = sqlite
+dataSourceName = data/casbin-gateway.db
+dbName =
 ```
 
-Casbin Gateway uses XORM to connect to DB, so all DBs supported by XORM can also be used.
+Docker Compose stores the database in the `gateway-data` volume. Kubernetes stores it in the `caswaf-data` persistent volume claim.
+
+MySQL and PostgreSQL remain available when an external database is needed. Set `driverName`, `dataSourceName`, and `dbName` in `conf/app.conf` for the selected database.
 
 #### Run Casbin Gateway
 

--- a/conf/app.conf
+++ b/conf/app.conf
@@ -5,11 +5,11 @@ runmode = dev
 SessionOn = true
 copyrequestbody = true
 
-; Database. Casbin Gateway creates "dbName" on first start if it does not exist.
-; XORM is used, so mysql, postgres, mssql and sqlite are all supported.
-driverName = mysql
-dataSourceName = root:123@tcp(localhost:3306)/
-dbName = caswaf
+; SQLite is used by default and its database file is created automatically.
+; MySQL, PostgreSQL and MSSQL can be configured through XORM when needed.
+driverName = sqlite
+dataSourceName = data/casbin-gateway.db
+dbName =
 ; Optional Redis for sessions. Sessions are kept in ./tmp files when empty.
 redisEndpoint =
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.1'
 services:
   caswaf:
     build:
@@ -6,17 +5,9 @@ services:
       dockerfile: Dockerfile
     ports:
       - "17000:17000"
-    depends_on:
-      - db
-    command: ["./wait-for-it", "db:3306", "--", "./server"]
     volumes:
       - ./conf:/conf/
-  db:
-    restart: always
-    image: mysql:8.0.25
-    ports:
-      - "3306:3306"
-    environment:
-      MYSQL_ROOT_PASSWORD: 123
-    volumes:
-      - /usr/local/docker/mysql:/var/lib/mysql
+      - gateway-data:/data
+
+volumes:
+  gateway-data:

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -1,370 +1,81 @@
 # Kubernetes Deployment Guide for Casbin Gateway
 
-This guide provides instructions for deploying Casbin Gateway on Kubernetes.
+Casbin Gateway uses SQLite by default. The Kubernetes manifests run one Gateway replica and persist the SQLite database in the `caswaf-data` persistent volume claim, so no database service is required.
 
 ## Prerequisites
 
-- A running Kubernetes cluster (1.19+)
-- `kubectl` configured to access your cluster
-- A running Casdoor instance (can be in the same cluster or external)
-- Basic understanding of Kubernetes resources
+- A Kubernetes cluster with a default storage class
+- `kubectl` configured for the cluster
+- A reachable Casdoor instance
 
-## Architecture
+## Configure Casdoor
 
-The deployment consists of:
-- **Casbin Gateway Application**: The main WAF application
-- **MySQL Database**: Stores Casbin Gateway configuration and data
-- **Secrets**: Stores sensitive credentials (Casdoor client ID/secret, MySQL password)
-- **ConfigMap**: Contains Casbin Gateway configuration template
-- **Services**: Exposes Casbin Gateway and MySQL within the cluster
-- **Ingress** (optional): Exposes Casbin Gateway externally
+Replace the two placeholders in `secret.yaml` with the client ID and client secret from your Casdoor application. If Casdoor is not available at the default in-cluster address, update `casdoorEndpoint` in `configmap.yaml`.
 
-## Quick Start
+## Deploy
 
-### 1. Deploy Casdoor (if not already deployed)
-
-Casbin Gateway requires Casdoor for authentication. If you don't have Casdoor deployed:
+From the `k8s` directory, run:
 
 ```bash
-# Follow Casdoor's Kubernetes deployment guide:
-# https://casdoor.org/docs/deployment/k8s
-```
-
-### 2. Configure Secrets
-
-Edit `k8s/secret.yaml` and update the sensitive credentials:
-
-```yaml
-stringData:
-  casdoor-client-id: "YOUR_ACTUAL_CLIENT_ID"
-  casdoor-client-secret: "YOUR_ACTUAL_CLIENT_SECRET"
-  mysql-password: "YOUR_STRONG_PASSWORD"
-```
-
-**Important**: 
-- **REQUIRED**: You must replace all placeholder values before deployment
-- Get `casdoor-client-id` and `casdoor-client-secret` from your Casdoor application settings
-- Use a strong password for `mysql-password` (min 12 characters recommended)
-- This password must match the one in `k8s/mysql.yaml`
-- The deployment will fail with validation errors if placeholders are not replaced
-
-**Security Best Practice**: Never commit actual secrets to version control. Consider using:
-- [Sealed Secrets](https://github.com/bitnami-labs/sealed-secrets)
-- [External Secrets Operator](https://external-secrets.io/)
-- Cloud provider secret management (AWS Secrets Manager, Azure Key Vault, GCP Secret Manager)
-
-### 3. Configure MySQL Password
-
-Edit `k8s/mysql.yaml` and update the MySQL root password:
-
-```bash
-# Generate base64 encoded password (use the same password as in secret.yaml)
-echo -n "YOUR_SECURE_PASSWORD" | base64
-```
-
-Then update the `mysql-root-password` in the Secret resource with the base64 value.
-
-### 4. Configure Casdoor Endpoint (Optional)
-
-If your Casdoor is not at `http://casdoor.casdoor-system.svc.cluster.local:8000`, edit `k8s/configmap.yaml`:
-
-```yaml
-casdoorEndpoint: http://your-casdoor-service:port
-```
-
-### 5. Deploy to Kubernetes
-
-**Option A: Using the deployment script (Recommended)**
-
-The easiest way to deploy Casbin Gateway:
-
-```bash
-cd k8s
 chmod +x deploy.sh
 ./deploy.sh
 ```
 
-The script will:
-- Validate your configuration
-- Deploy MySQL and wait for it to be ready
-- Deploy secrets and configuration
-- Deploy Casbin Gateway application
-- Optionally deploy Ingress
-- Show deployment status
+Alternatively, deploy all default resources with Kustomize:
 
-**Option B: Using individual files**
-
-```bash
-# Create namespace and deploy MySQL
-kubectl apply -f k8s/mysql.yaml
-
-# Wait for MySQL to be ready
-kubectl wait --for=condition=ready pod -l app=caswaf-mysql -n caswaf --timeout=300s
-
-# Deploy Secrets
-kubectl apply -f k8s/secret.yaml
-
-# Deploy ConfigMap
-kubectl apply -f k8s/configmap.yaml
-
-# Deploy Casbin Gateway
-kubectl apply -f k8s/deployment.yaml
-
-# (Optional) Deploy Ingress
-kubectl apply -f k8s/ingress.yaml
-```
-
-**Option C: Using Kustomize**
 ```bash
 kubectl apply -k k8s/
 ```
 
-### 6. Verify Deployment
+The default resources include the application, Casdoor configuration, a 1 Gi SQLite persistent volume claim, and the optional ingress manifest. They do not deploy MySQL.
 
-```bash
-# Check if pods are running
-kubectl get pods -n caswaf
+## Access the application
 
-# Check logs
-kubectl logs -f deployment/caswaf -n caswaf
+For local access without an ingress controller:
 
-# Check services
-kubectl get svc -n caswaf
-```
-
-### 7. Access Casbin Gateway
-
-If using Ingress:
-```bash
-# Update your DNS or /etc/hosts to point to your ingress controller IP
-# Then access: http://caswaf.example.com
-```
-
-If using port-forward for testing:
 ```bash
 kubectl port-forward svc/caswaf 17000:17000 -n caswaf
-# Access: http://localhost:17000
 ```
 
-## Configuration Details
+Then open `http://localhost:17000`. To use Ingress, change the host in `ingress.yaml` before deployment.
 
-### Secrets (`secret.yaml`)
+## Database configuration
 
-Stores sensitive credentials:
-- `casdoor-client-id`: Casdoor application client ID
-- `casdoor-client-secret`: Casdoor application client secret  
-- `mysql-password`: MySQL root password (must match mysql.yaml)
+The default database settings in `configmap.yaml` are:
 
-**Security Note**: Never commit actual secrets to version control. Use sealed-secrets, external secret operators, or other secret management solutions in production.
-
-### ConfigMap (`configmap.yaml`)
-
-Key configuration parameters:
-
-| Parameter | Description | Default |
-|-----------|-------------|---------|
-| `httpport` | Casbin Gateway HTTP port | `17000` |
-| `runmode` | Run mode (dev/prod) | `prod` |
-| `driverName` | Database driver | `mysql` |
-| `dataSourceName` | MySQL connection string | Uses secrets substitution |
-| `dbName` | Database name | `caswaf` |
-| `casdoorEndpoint` | Casdoor API endpoint | Required |
-| `casdoorInsecureSkipVerify` | Skip TLS verification for Casdoor | `true` |
-| `clientId` | Casdoor application client ID | Uses secrets substitution |
-| `clientSecret` | Casdoor application client secret | Uses secrets substitution |
-| `casdoorOrganization` | Casdoor organization name | `built-in` |
-| `casdoorApplication` | Casdoor application name | Required |
-
-### MySQL Deployment (`mysql.yaml`)
-
-- Uses MySQL 8.0.36 (latest stable)
-- Persistent storage with PVC (10Gi)
-- Includes health checks (liveness and readiness probes)
-- Root password stored in Kubernetes Secret with obvious placeholder
-
-### Casbin Gateway Deployment (`deployment.yaml`)
-
-Features:
-- Init containers:
-  - Wait for MySQL readiness
-  - Substitute secrets into configuration file
-- TCP-based liveness and readiness probes (no authentication required)
-- Resource limits and requests
-- Configuration mounted from ConfigMap with secret substitution
-
-## Troubleshooting
-
-### Common Issues
-
-#### 1. "wait-for-it: timeout occurred after waiting 15 seconds for db:3306"
-
-**Note**: This issue is fixed in the current deployment by using an init container instead of wait-for-it.
-
-**Cause**: MySQL is not ready or not accessible
-
-**Solution**:
-```bash
-# Check MySQL pod status
-kubectl get pods -n caswaf -l app=caswaf-mysql
-
-# Check MySQL logs
-kubectl logs -n caswaf -l app=caswaf-mysql
-
-# Verify MySQL service
-kubectl get svc -n caswaf caswaf-mysql
+```ini
+driverName = sqlite
+dataSourceName = /data/casbin-gateway.db
+dbName =
 ```
 
-#### 2. "casdoorsdk.GetCerts() error: Unauthorized operation"
+The deployment mounts `caswaf-data` at `/data`. SQLite is intended for the default single-replica deployment.
 
-**Cause**: Incorrect Casdoor configuration or credentials
+To use an external MySQL or PostgreSQL database, change these settings in `configmap.yaml` and provide the appropriate connection string. The legacy `mysql.yaml` manifest is available as an optional example but is not part of the default Kustomize deployment.
 
-**Solution**:
-1. Verify Casdoor is accessible:
-   ```bash
-   kubectl run -it --rm debug --image=curlimages/curl --restart=Never -n caswaf -- \
-     curl -v http://casdoor.casdoor-system.svc.cluster.local:8000
-   ```
-
-2. Verify `clientId` and `clientSecret` in ConfigMap match your Casdoor application
-
-3. Ensure the Casdoor application is configured correctly:
-   - Organization name matches `casdoorOrganization`
-   - Application name matches `casdoorApplication`
-   - Client ID and secret are correct
-
-4. Check Casdoor logs for authentication errors
-
-#### 3. Database Connection Issues
-
-**Solution**:
-```bash
-# Test MySQL connection from Casbin Gateway pod
-kubectl exec -it deployment/caswaf -n caswaf -- sh
-# Then inside the pod:
-# nc -zv caswaf-mysql 3306
-```
-
-#### 4. Init Container Stuck
-
-If the init container is stuck waiting for MySQL:
-```bash
-# Check init container logs
-kubectl logs -n caswaf <pod-name> -c wait-for-mysql
-
-# Force restart
-kubectl rollout restart deployment/caswaf -n caswaf
-```
-
-### Viewing Logs
+## Verify and troubleshoot
 
 ```bash
-# Casbin Gateway logs
+kubectl get pods -n caswaf
+kubectl get pvc -n caswaf
 kubectl logs -f deployment/caswaf -n caswaf
-
-# MySQL logs
-kubectl logs -f deployment/caswaf-mysql -n caswaf
-
-# All logs in namespace
-kubectl logs -f -n caswaf --all-containers=true
 ```
 
-## Production Recommendations
+If the pod is pending, check that the cluster has a default storage class capable of binding the `caswaf-data` claim. If authentication fails, verify the Casdoor endpoint, client ID, client secret, organization, and application in `configmap.yaml` and `secret.yaml`.
 
-1. **Use External MySQL**: For production, consider using a managed MySQL service (AWS RDS, Google Cloud SQL, etc.)
+## Updating
 
-2. **Configure TLS**: 
-   - Set `casdoorInsecureSkipVerify = false`
-   - Use proper TLS certificates for Casdoor
-
-3. **Resource Limits**: Adjust resource limits based on your traffic:
-   ```yaml
-   resources:
-     requests:
-       memory: "512Mi"
-       cpu: "500m"
-     limits:
-       memory: "2Gi"
-       cpu: "2000m"
-   ```
-
-4. **High Availability**:
-   - Increase replicas for Casbin Gateway
-   - Use MySQL replication or managed service
-   - Configure proper health checks
-
-5. **Monitoring**: Set up monitoring and alerting:
-   - Prometheus metrics
-   - Application logs
-   - Resource usage
-
-6. **Backup**: Regular backups of MySQL data
-
-7. **Security**:
-   - Use Kubernetes Secrets for sensitive data
-   - Enable RBAC
-   - Network policies to restrict traffic
-   - Regular security updates
-
-## Updating Casbin Gateway
+Update the image and watch the rollout:
 
 ```bash
-# Update the image version in deployment.yaml, then:
 kubectl set image deployment/caswaf caswaf=casbin/caswaf:NEW_VERSION -n caswaf
-
-# Or apply updated deployment
-kubectl apply -f k8s/deployment.yaml
-
-# Check rollout status
 kubectl rollout status deployment/caswaf -n caswaf
 ```
 
 ## Uninstall
 
-```bash
-# Delete all resources
-kubectl delete -f k8s/ingress.yaml
-kubectl delete -f k8s/deployment.yaml
-kubectl delete -f k8s/configmap.yaml
-kubectl delete -f k8s/mysql.yaml
+Delete the namespace to remove all resources. This also deletes the SQLite persistent volume claim; whether the underlying volume is retained depends on the storage class reclaim policy.
 
-# Or delete the entire namespace
+```bash
 kubectl delete namespace caswaf
 ```
-
-## Advanced Configuration
-
-### Using External MySQL
-
-Edit `configmap.yaml`:
-```yaml
-dataSourceName: root:password@tcp(external-mysql.example.com:3306)/
-```
-
-Then skip deploying `mysql.yaml`.
-
-### Using Redis for Sessions
-
-Edit `configmap.yaml`:
-```yaml
-redisEndpoint: redis-host:6379
-```
-
-### Custom Domain
-
-Edit `ingress.yaml`:
-```yaml
-spec:
-  rules:
-  - host: waf.yourdomain.com
-```
-
-## Support
-
-For issues and questions:
-- GitHub Issues: https://github.com/apache/casbin-gateway/issues
-- Documentation: https://caswaf.org
-- Casdoor Documentation: https://casdoor.org
-
-## License
-
-Apache-2.0

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -11,9 +11,9 @@ data:
     runmode = prod
     SessionOn = true
     copyrequestbody = true
-    driverName = mysql
-    dataSourceName = root:MYSQL_PASSWORD_PLACEHOLDER@tcp(caswaf-mysql:3306)/
-    dbName = caswaf
+    driverName = sqlite
+    dataSourceName = /data/casbin-gateway.db
+    dbName =
     redisEndpoint =
     gatewayEnabled = false
     gatewayHttpPort = 80

--- a/k8s/deploy.sh
+++ b/k8s/deploy.sh
@@ -55,42 +55,20 @@ if grep -q "CHANGEME_INSECURE_DEFAULT_REPLACE_THIS" secret.yaml; then
     echo "Please edit k8s/secret.yaml and replace all placeholder values with your actual credentials:"
     echo "  - casdoor-client-id"
     echo "  - casdoor-client-secret"
-    echo "  - mysql-password"
-    echo
-    echo "Also update k8s/mysql.yaml with the base64 encoded password:"
-    echo "  echo -n 'your-password' | base64"
-    exit 1
-fi
-
-if grep -q "CHANGEME_INSECURE_DEFAULT_REPLACE_THIS" mysql.yaml; then
-    echo -e "${RED}Error: MySQL password has not been configured!${NC}"
-    echo "Please edit k8s/mysql.yaml and set a strong password (base64 encoded)"
-    echo "  echo -n 'your-strong-password' | base64"
     exit 1
 fi
 
 echo -e "${GREEN}✓ Configuration looks good${NC}"
 echo
 
-echo -e "${YELLOW}Step 2: Deploying MySQL...${NC}"
-kubectl apply -f mysql.yaml
-
-echo "Waiting for MySQL to be ready..."
-kubectl wait --for=condition=ready pod -l app=caswaf-mysql -n caswaf --timeout=300s || {
-    echo -e "${RED}Error: MySQL failed to start${NC}"
-    echo "Check logs with: kubectl logs -n caswaf -l app=caswaf-mysql"
-    exit 1
-}
-echo -e "${GREEN}✓ MySQL is ready${NC}"
-echo
-
-echo -e "${YELLOW}Step 3: Deploying Casbin Gateway configuration...${NC}"
+echo -e "${YELLOW}Step 2: Deploying Casbin Gateway configuration and storage...${NC}"
+kubectl apply -f sqlite-pvc.yaml
 kubectl apply -f secret.yaml
 kubectl apply -f configmap.yaml
 echo -e "${GREEN}✓ Configuration deployed${NC}"
 echo
 
-echo -e "${YELLOW}Step 4: Deploying Casbin Gateway application...${NC}"
+echo -e "${YELLOW}Step 3: Deploying Casbin Gateway application...${NC}"
 kubectl apply -f deployment.yaml
 
 echo "Waiting for Casbin Gateway to be ready..."
@@ -119,7 +97,7 @@ if [ -z "$AUTO_INGRESS" ]; then
 fi
 
 if [ "$AUTO_INGRESS" = "yes" ]; then
-    echo -e "${YELLOW}Step 5: Deploying Ingress...${NC}"
+    echo -e "${YELLOW}Step 4: Deploying Ingress...${NC}"
     kubectl apply -f ingress.yaml
     echo -e "${GREEN}✓ Ingress deployed${NC}"
     echo

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -15,17 +15,6 @@ spec:
         app: caswaf
     spec:
       initContainers:
-        - name: wait-for-mysql
-          image: busybox:1.36
-          command:
-            - sh
-            - -c
-            - |
-              until timeout 1 sh -c 'cat < /dev/null > /dev/tcp/caswaf-mysql/3306' 2>/dev/null; do
-                echo "Waiting for MySQL to be ready..."
-                sleep 2
-              done
-              echo "MySQL is ready!"
         - name: setup-config
           image: busybox:1.36
           command:
@@ -36,11 +25,6 @@ spec:
               PLACEHOLDER="CHANGEME_INSECURE_DEFAULT_REPLACE_THIS"
               
               # Validate that secrets have been replaced
-              if [ "$MYSQL_PASSWORD" = "$PLACEHOLDER" ]; then
-                echo "ERROR: MySQL password has not been configured!"
-                echo "Please update k8s/secret.yaml with your actual MySQL password"
-                exit 1
-              fi
               if [ "$CASDOOR_CLIENT_ID" = "$PLACEHOLDER" ]; then
                 echo "ERROR: Casdoor client ID has not been configured!"
                 echo "Please update k8s/secret.yaml with your actual Casdoor client ID"
@@ -54,16 +38,10 @@ spec:
               
               # All validations passed, proceed with configuration
               cp /tmp/config/app.conf /conf-out/app.conf
-              sed -i "s/MYSQL_PASSWORD_PLACEHOLDER/${MYSQL_PASSWORD}/g" /conf-out/app.conf
               sed -i "s/CLIENT_ID_PLACEHOLDER/${CASDOOR_CLIENT_ID}/g" /conf-out/app.conf
               sed -i "s/CLIENT_SECRET_PLACEHOLDER/${CASDOOR_CLIENT_SECRET}/g" /conf-out/app.conf
               echo "Configuration prepared successfully"
           env:
-            - name: MYSQL_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: caswaf-secrets
-                  key: mysql-password
             - name: CASDOOR_CLIENT_ID
               valueFrom:
                 secretKeyRef:
@@ -82,6 +60,7 @@ spec:
       containers:
         - name: caswaf
           image: casbin/caswaf:latest
+          command: ["./server"]
           ports:
             - containerPort: 17000
               name: http
@@ -92,6 +71,8 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /conf
+            - name: data
+              mountPath: /data
           livenessProbe:
             tcpSocket:
               port: 17000
@@ -119,6 +100,9 @@ spec:
             name: caswaf-config
         - name: config
           emptyDir: {}
+        - name: data
+          persistentVolumeClaim:
+            claimName: caswaf-data
 ---
 apiVersion: v1
 kind: Service

--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -5,9 +5,9 @@ kind: Kustomization
 namespace: caswaf
 
 resources:
-  - mysql.yaml
   - secret.yaml
   - configmap.yaml
+  - sqlite-pvc.yaml
   - deployment.yaml
   - ingress.yaml
 

--- a/k8s/secret.yaml
+++ b/k8s/secret.yaml
@@ -10,6 +10,3 @@ stringData:
   # Get these from your Casdoor application settings
   casdoor-client-id: "CHANGEME_INSECURE_DEFAULT_REPLACE_THIS"
   casdoor-client-secret: "CHANGEME_INSECURE_DEFAULT_REPLACE_THIS"
-  # MySQL password - REQUIRED: Replace with a strong password
-  # This must match the password in mysql.yaml secret
-  mysql-password: "CHANGEME_INSECURE_DEFAULT_REPLACE_THIS"

--- a/k8s/sqlite-pvc.yaml
+++ b/k8s/sqlite-pvc.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: caswaf
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: caswaf-data
+  namespace: caswaf
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/object/ormer.go
+++ b/object/ormer.go
@@ -18,6 +18,8 @@ import (
 	"database/sql"
 	"flag"
 	"fmt"
+	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 
@@ -63,14 +65,25 @@ func InitConfig() {
 }
 
 func InitAdapter() {
+	driverName := conf.GetConfigString("driverName")
+	dataSourceName := conf.GetConfigDataSourceName()
+	if driverName == "sqlite" {
+		dir := filepath.Dir(dataSourceName)
+		if dir != "." {
+			if err := os.MkdirAll(dir, 0o755); err != nil {
+				panic(err)
+			}
+		}
+	}
+
 	if createDatabase {
-		err := createDatabaseForPostgres(conf.GetConfigString("driverName"), conf.GetConfigDataSourceName(), conf.GetConfigString("dbName"))
+		err := createDatabaseForPostgres(driverName, dataSourceName, conf.GetConfigString("dbName"))
 		if err != nil {
 			panic(err)
 		}
 	}
 
-	ormer = NewAdapter(conf.GetConfigString("driverName"), conf.GetConfigDataSourceName(), conf.GetConfigString("dbName"))
+	ormer = NewAdapter(driverName, dataSourceName, conf.GetConfigString("dbName"))
 
 	tableNamePrefix := conf.GetConfigString("tableNamePrefix")
 	tbMapper := core.NewPrefixMapper(core.SnakeMapper{}, tableNamePrefix)
@@ -98,7 +111,7 @@ func PingDatabase() error {
 	return ormer.Engine.Ping()
 }
 
-// Ormer represents the MySQL adapter for policy storage.
+// Ormer represents the database adapter for policy storage.
 type Ormer struct {
 	driverName     string
 	dataSourceName string
@@ -152,7 +165,7 @@ func createDatabaseForPostgres(driverName string, dataSourceName string, dbName 
 }
 
 func (a *Ormer) CreateDatabase() error {
-	if a.driverName == "postgres" {
+	if a.driverName != "mysql" {
 		return nil
 	}
 

--- a/object/record.go
+++ b/object/record.go
@@ -104,8 +104,12 @@ type DataCount struct {
 
 func GetMetrics(dataType string, startAt time.Time, top int) (*[]DataCount, error) {
 	var dataCounts []DataCount
+	createdAfter := "UNIX_TIMESTAMP(created_time) > ?"
+	if ormer.driverName == "sqlite" {
+		createdAfter = "CAST(strftime('%s', created_time) AS INTEGER) > ?"
+	}
 	err := ormer.Engine.Table("record").
-		Where("UNIX_TIMESTAMP(created_time) > ?", startAt.Unix()).
+		Where(createdAfter, startAt.Unix()).
 		Select(dataType + " as data, COUNT(*) as count").
 		GroupBy("data").
 		Desc("count").
@@ -120,8 +124,13 @@ func GetMetrics(dataType string, startAt time.Time, top int) (*[]DataCount, erro
 func GetMetricsOverTime(startAt time.Time, timeType string) (*[]DataCount, error) {
 	var dataCounts []DataCount
 	createdTime := "DATE_FORMAT(created_time, '" + timeType2Format(timeType) + "')"
+	createdAfter := "UNIX_TIMESTAMP(created_time) > ?"
+	if ormer.driverName == "sqlite" {
+		createdTime = "strftime('" + timeType2Format(timeType) + "', created_time)"
+		createdAfter = "CAST(strftime('%s', created_time) AS INTEGER) > ?"
+	}
 	err := ormer.Engine.Table("record").
-		Where("UNIX_TIMESTAMP(created_time) > ?", startAt.Unix()).
+		Where(createdAfter, startAt.Unix()).
 		GroupBy(createdTime).
 		Select(createdTime + " as data, COUNT(*) as count").
 		Asc("data").

--- a/service/startup.go
+++ b/service/startup.go
@@ -77,9 +77,13 @@ func describeGatewayPort(port int) string {
 }
 
 func describeDatabase() string {
-	// The connection string holds the database password, so only the driver and
-	// the database name are ever printed.
-	target := fmt.Sprintf("%s, database \"%s\"", unquote(conf.GetConfigString("driverName")), unquote(conf.GetConfigString("dbName")))
+	// External connection strings can contain passwords, so only SQLite's local
+	// file path is safe to show in full.
+	driverName := unquote(conf.GetConfigString("driverName"))
+	target := fmt.Sprintf("%s, database \"%s\"", driverName, unquote(conf.GetConfigString("dbName")))
+	if driverName == "sqlite" {
+		target = fmt.Sprintf("sqlite, file \"%s\"", unquote(conf.GetConfigDataSourceName()))
+	}
 
 	err := object.PingDatabase()
 	if err != nil {


### PR DESCRIPTION
## Summary

- Use SQLite as the default database for native, Docker, Kubernetes, and CI environments
- Remove the default MySQL service and startup wait logic
- Persist SQLite data with Docker volumes and a Kubernetes PVC
- Support metrics queries when using SQLite
- Update the deployment documentation accordingly

MySQL and PostgreSQL remain available as optional external databases.