### PR TITLE
fix(channel): drop unsupported claude/gemini channel types

### DIFF
--- a/object/channel.go
+++ b/object/channel.go
@@ -44,11 +44,10 @@ const (
 )
 
 var (
-	channelTypes    = []string{"openai", "claude", "gemini", "custom"}
+	channelTypes    = []string{"openai", "custom"}
 	channelStatuses = []string{"enabled", "disabled"}
 	// openAiCompatibleChannelTypes are the types whose upstream speaks the
-	// OpenAI HTTP API, which is the only wire format the gateway can talk so
-	// far. The claude and gemini types need their own request translation.
+	// OpenAI HTTP API, which is the only wire format the gateway can talk.
 	openAiCompatibleChannelTypes = []string{"openai", "custom"}
 )
 

--- a/web/src/ChannelEditPage.js
+++ b/web/src/ChannelEditPage.js
@@ -24,8 +24,6 @@ const {Option} = Select;
 // Hard-coded presets for milestone 1.1 (per channel type).
 const BASE_URL_PRESETS = {
   openai: ["https://api.openai.com/v1"],
-  claude: ["https://api.anthropic.com/v1"],
-  gemini: ["https://generativelanguage.googleapis.com/v1beta"],
   custom: ["https://oneapi.example.com", "https://api.deepseek.com/v1", "https://api.moonshot.cn/v1"],
 };
 
@@ -58,8 +56,6 @@ function buildOpenAiUrl(baseUrl, endpoint) {
 
 const MODEL_PRESETS = {
   openai: ["gpt-5.5", "gpt-5", "gpt-5-mini", "o3", "o4-mini"],
-  claude: ["claude-sonnet-5", "claude-opus-4-8", "claude-haiku-4-5"],
-  gemini: ["gemini-3.6-flash", "gemini-3.5-flash-lite", "gemini-2.5-pro"],
   custom: ["deepseek-chat", "deepseek-reasoner", "moonshot-v1-8k", "qwen-max"],
 };
 
@@ -151,6 +147,22 @@ class ChannelEditPage extends React.Component {
     );
   }
 
+  renderUnsupportedTypeAlert(channel) {
+    if (OPENAI_COMPATIBLE_TYPES.includes(channel.type)) {
+      return null;
+    }
+
+    return (
+      <Alert
+        style={{marginBottom: "20px"}}
+        type="warning"
+        showIcon
+        message={i18next.t("channel:Unsupported channel type")}
+        description={i18next.t("channel:This channel type is no longer supported. Change it to a supported type or delete the channel.")}
+      />
+    );
+  }
+
   render() {
     const channel = this.state.channel;
     if (channel === undefined) {
@@ -187,16 +199,21 @@ class ChannelEditPage extends React.Component {
             >
               {i18next.t("general:Save")}
             </Button>
-            <Button
-              icon={<ThunderboltOutlined />}
-              loading={this.state.testing}
-              onClick={this.test.bind(this)}
-            >
-              {i18next.t("channel:Test Connectivity")}
-            </Button>
+            {
+              OPENAI_COMPATIBLE_TYPES.includes(channel.type) ? (
+                <Button
+                  icon={<ThunderboltOutlined />}
+                  loading={this.state.testing}
+                  onClick={this.test.bind(this)}
+                >
+                  {i18next.t("channel:Test Connectivity")}
+                </Button>
+              ) : null
+            }
           </Space>
         }
       >
+        {this.renderUnsupportedTypeAlert(channel)}
         <Row style={{marginTop: "10px"}}>
           <Col style={{marginTop: "5px"}} span={2}>
             {i18next.t("general:Display name")}:
@@ -223,9 +240,12 @@ class ChannelEditPage extends React.Component {
                 this.setChannelField("type", value);
               }}
             >
+              {
+                !OPENAI_COMPATIBLE_TYPES.includes(channel.type) ? (
+                  <Option value={channel.type} disabled>{`${channel.type} (${i18next.t("channel:Unsupported")})`}</Option>
+                ) : null
+              }
               <Option value="openai">OpenAI</Option>
-              <Option value="claude">Claude (Anthropic)</Option>
-              <Option value="gemini">Gemini (Google)</Option>
               <Option value="custom">Custom</Option>
             </Select>
           </Col>

--- a/web/src/ChannelListPage.js
+++ b/web/src/ChannelListPage.js
@@ -105,12 +105,10 @@ class ChannelListPage extends BaseListPage {
   renderTypeTag(type) {
     const colorMap = {
       openai: "#10a37f",
-      claude: "#d97757",
-      gemini: "#4285f4",
       custom: "#8b5cf6",
     };
     return (
-      <Tag color={colorMap[type] || "default"}>{type}</Tag>
+      <Tag color={colorMap[type] || "#595959"}>{colorMap[type] ? type : `${type} (${i18next.t("channel:Unsupported")})`}</Tag>
     );
   }
 

--- a/web/src/locales/en/data.json
+++ b/web/src/locales/en/data.json
@@ -114,6 +114,9 @@
     "Priority": "Priority",
     "Priority hint": "Smaller number means higher priority, 0 is the highest; when multiple channels serve the same model, the one with the smaller value is used first.",
     "Status": "Status",
+    "Unsupported": "Unsupported",
+    "Unsupported channel type": "Unsupported channel type",
+    "This channel type is no longer supported. Change it to a supported type or delete the channel.": "This channel type is no longer supported. Change it to a supported type or delete the channel.",
     "Test Connectivity": "Test Connectivity",
     "Type": "Type"
   },

--- a/web/src/locales/zh/data.json
+++ b/web/src/locales/zh/data.json
@@ -114,6 +114,9 @@
     "Priority": "优先级",
     "Priority hint": "数字越小优先级越高，0 为最高；同模型多渠道时优先使用数值小的渠道。",
     "Status": "状态",
+    "Unsupported": "不受支持",
+    "Unsupported channel type": "不受支持的渠道类型",
+    "This channel type is no longer supported. Change it to a supported type or delete the channel.": "该渠道类型已不再受支持。请将其改为受支持的类型，或删除该渠道。",
     "Test Connectivity": "测试连接",
     "Type": "类型"
   },


### PR DESCRIPTION
## <span data-type="text" style="font-size: 1.38em;"># Why</span>

A channel whose type the gateway cannot serve — claude or gemini — could still be created in the web UI, filled in with a base URL and an API key, and even tested. Every such action dead-ended in `the claude/gemini channel type is not supported yet in this stage`, because the gateway only speaks the OpenAI wire format (`BuildOpenAiUrl` / `forwardToChannel`). Letting users create channel types the product cannot talk to was a self-contradiction.

### # What changed

- `object/channel.go`: narrowed `channelTypes` to `["openai", "custom"]`. `validateChannel` now rejects claude/gemini on create and update, and `IsChannelOpenAiCompatible` no longer treats them as usable. The "not supported" guard in `TestChannelConnectivity` / `channelUnusableReason` stays as a defensive fallback for legacy rows already in the database.
- `web/src/ChannelEditPage.js`: the type dropdown offers only OpenAI/Custom; claude/gemini base-URL and model presets are removed; the "Test Connectivity" button and the upstream-URL hint are only shown for OpenAI-compatible types.
- `web/src/ChannelListPage.js`: dropped the claude/gemini type-tag colors.

### # Verification

- `go build ./object/ ./controllers/` passes.
- `controllers/proxy_test.go` still exercises the "not supported" guard for a legacy claude channel.