### PR TITLE
fix: probe requests reuse the configured httpProxy 

### DIFF
--- a/controllers/proxy.go
+++ b/controllers/proxy.go
@@ -24,9 +24,11 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/apache/casbin-gateway/object"
+	"github.com/apache/casbin-gateway/proxy"
 	"github.com/beego/beego"
 )
 
@@ -71,13 +73,22 @@ type openaiErrorDetail struct {
 	Type    string `json:"type"`
 }
 
-// proxyClient is a shared HTTP client for upstream requests.
-// Reusing a single instance allows TCP connection pooling across requests.
-// It has no overall Timeout on purpose, see proxyResponseHeaderTimeout.
-var proxyClient = &http.Client{
-	CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
-	Transport: &http.Transport{
-		Proxy: http.ProxyFromEnvironment,
+var (
+	proxyClient     *http.Client
+	proxyClientOnce sync.Once
+)
+
+// getProxyClient creates the shared client after application configuration is
+// loaded, including when the embedded binary supplies app.conf at startup.
+func getProxyClient() *http.Client {
+	proxyClientOnce.Do(func() {
+		proxyClient = newProxyClient()
+	})
+	return proxyClient
+}
+
+func newProxyClient() *http.Client {
+	transport := &http.Transport{
 		DialContext: (&net.Dialer{
 			Timeout:   10 * time.Second,
 			KeepAlive: 30 * time.Second,
@@ -88,7 +99,12 @@ var proxyClient = &http.Client{
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
 		ResponseHeaderTimeout: proxyResponseHeaderTimeout,
-	},
+	}
+	proxy.ConfigureTransport(transport)
+	return &http.Client{
+		CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
+		Transport:     transport,
+	}
 }
 
 // ChatCompletions is the OpenAI-compatible chat completions proxy endpoint.
@@ -187,7 +203,7 @@ func (c *ApiController) forwardToChannel(channel *object.Channel, rawBody []byte
 	upstreamReq.Header.Set("Content-Type", "application/json")
 	upstreamReq.Header.Set("Authorization", "Bearer "+channel.ApiKey)
 
-	upstreamResp, err := proxyClient.Do(upstreamReq)
+	upstreamResp, err := getProxyClient().Do(upstreamReq)
 	if err != nil {
 		if c.Ctx.Request.Context().Err() != nil {
 			// The client hung up mid-request, there is nothing left to answer.

--- a/object/cert_whois.go
+++ b/object/cert_whois.go
@@ -47,12 +47,6 @@ func getDomainExpireTime(domainName string) (string, error) {
 	}
 
 	client := whois.NewClient()
-	//if server != "whois.cnnic.cn" && server != "grs-whois.hichina.com" {
-	//	dialer := proxy.GetProxyDialer()
-	//	if dialer != nil {
-	//		client.SetDialer(dialer)
-	//	}
-	//}
 
 	data, err := client.Whois(domainName, server)
 	if err != nil {

--- a/object/channel.go
+++ b/object/channel.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/apache/casbin-gateway/proxy"
 	"github.com/apache/casbin-gateway/util"
 	"github.com/xorm-io/core"
 )
@@ -306,7 +307,8 @@ func TestChannelConnectivity(channel *Channel) (bool, int, string) {
 	}
 
 	client := &http.Client{
-		Timeout: 10 * time.Second,
+		Timeout:   10 * time.Second,
+		Transport: proxy.NewTransport(),
 		// Do not follow redirects, so the reported status is the one the
 		// configured base URL actually returns.
 		CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },

--- a/object/site_cert_account.go
+++ b/object/site_cert_account.go
@@ -17,6 +17,7 @@ package object
 import (
 	"crypto"
 	"fmt"
+	"net/http"
 
 	"github.com/apache/casbin-gateway/proxy"
 	"github.com/beego/beego"
@@ -70,7 +71,7 @@ func getLegoClientAndAccount(email string, privateKey string, devMode bool, useP
 	if useProxy {
 		config.HTTPClient = proxy.ProxyHttpClient
 	} else {
-		config.HTTPClient = proxy.DefaultHttpClient
+		config.HTTPClient = http.DefaultClient
 	}
 
 	client, err := lego.NewClient(config)

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -15,80 +15,34 @@
 package proxy
 
 import (
-	"fmt"
-	"net"
 	"net/http"
-	"time"
+	"net/url"
 
 	"github.com/beego/beego"
-	"golang.org/x/net/proxy"
 )
 
-var DefaultHttpClient *http.Client
 var ProxyHttpClient *http.Client
 
 func InitHttpClient() {
-	// not use proxy
-	DefaultHttpClient = http.DefaultClient
-
-	// use proxy
-	ProxyHttpClient = getProxyHttpClient()
+	ProxyHttpClient = &http.Client{Transport: NewTransport()}
 }
 
-func isAddressOpen(address string) bool {
-	timeout := time.Millisecond * 100
-	conn, err := net.DialTimeout("tcp", address, timeout)
-	if err != nil {
-		// cannot connect to address, proxy is not active
-		return false
-	}
-
-	if conn != nil {
-		defer conn.Close()
-		fmt.Printf("Socks5 proxy enabled: %s\n", address)
-		return true
-	}
-
-	return false
+// NewTransport returns a standard transport configured for outbound traffic.
+// An app.conf SOCKS5 proxy takes precedence over environment proxy variables.
+func NewTransport() *http.Transport {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	ConfigureTransport(transport)
+	return transport
 }
 
-func getProxyHttpClient() *http.Client {
+// ConfigureTransport applies the outbound proxy policy to transport.
+func ConfigureTransport(transport *http.Transport) {
 	httpProxy := beego.AppConfig.String("httpProxy")
 	if httpProxy == "" {
-		return &http.Client{}
+		transport.Proxy = http.ProxyFromEnvironment
+		return
 	}
 
-	if !isAddressOpen(httpProxy) {
-		return &http.Client{}
-	}
-
-	// https://stackoverflow.com/questions/33585587/creating-a-go-socks5-client
-	dialer, err := proxy.SOCKS5("tcp", httpProxy, nil, proxy.Direct)
-	if err != nil {
-		panic(err)
-	}
-
-	tr := &http.Transport{Dial: dialer.Dial}
-	return &http.Client{
-		Transport: tr,
-	}
-}
-
-func GetProxyDialer() *net.Dialer {
-	httpProxy := beego.AppConfig.String("httpProxy")
-	if httpProxy == "" {
-		return nil
-	}
-
-	if !isAddressOpen(httpProxy) {
-		return nil
-	}
-
-	// https://stackoverflow.com/questions/33585587/creating-a-go-socks5-client
-	dialer, err := proxy.SOCKS5("tcp", httpProxy, nil, proxy.Direct)
-	if err != nil {
-		panic(err)
-	}
-
-	return dialer.(*net.Dialer)
+	transport.Proxy = http.ProxyURL(&url.URL{Scheme: "socks5", Host: httpProxy})
+	beego.Trace("using SOCKS5 proxy for outbound traffic:", httpProxy)
 }


### PR DESCRIPTION
## Why

the channel probe (the "Test connection" button in the channel admin UI, which calls `object.TestChannelConnectivity`) and the `/v1/chat/completions` forwarding requests ignore the `httpProxy` (SOCKS5) already configured in `conf/app.conf`.

- The probe uses a bare `&http.Client{}` with the default transport, which only honors environment proxies; in a data center that cannot reach Google/OpenAI it just times out.
- The old `proxy` package had defects:

  - `GetProxyDialer()` (proxy/proxy.go:93) does an always-panicking type assertion — `x/net`'s `SOCKS5()` returns `*socks.Dialer`, not `*net.Dialer`.
  - `getProxyHttpClient()` returned a bare `&http.Client{}` without timeouts when the proxy liveness probe failed.
  - `isAddressOpen` decided once at startup and never re-checked, so a proxy that died at runtime was never recovered.

## What changed

- The `proxy` package now exposes a single entry point:

  - Added `NewTransport()` / `ConfigureTransport(*http.Transport)`: `app.conf` `httpProxy` takes precedence over environment variables; falls back to `HTTP_PROXY` / `HTTPS_PROXY` when unset.
  - Uses the stdlib `Transport.Proxy = http.ProxyURL(&url.URL{Scheme: "socks5", Host: httpProxy})` (native `socks5` scheme since Go 1.9) instead of a hand-rolled `x/net` dialer, net removing ~45 lines and dropping the `golang.org/x/net/proxy` dependency.
  - Removed the always-panicking `GetProxyDialer()` and the one-shot `isAddressOpen()`; an explicitly configured proxy is now mandatory (no silent fallback to direct); a `beego.Trace` log line confirms the proxy is active.
  - Removed the meaningless `DefaultHttpClient` alias; its only caller now uses the stdlib `http.DefaultClient`.
- `controllers/proxy.go`: the forwarding client is built lazily with `sync.Once`, so package-level initialization can no longer freeze the proxy policy before `app.conf` is loaded in embedded single-binary mode; keeps connection pooling, 10s TCP dial, 60s response-header and SSE idle timeouts, and redirect disabling.
- `object/channel.go`: `TestChannelConnectivity` (the "Test connection" button) now uses `proxy.NewTransport()`; the 10s overall timeout and the redirect policy are unchanged.
- `object/cert_whois.go`: removed a stale comment block referencing the deleted function.

## Verification

- `go test ./proxy ./object ./certificate -run '^$'`: compiles clean.
- `go test -tags embed ./controllers ./object -run '^$'`: compiles clean in embedded single-binary mode.
- With `httpProxy` set, the channel probe, `/v1/chat/completions` forwarding and ACME requests all egress via the SOCKS5 proxy; without it, environment proxies are used.