### PR TITLE
fix(web): switch language reactively without a full page reload

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -14,6 +14,7 @@
 
 import * as React from "react";
 import {Navigate, Route, Routes, useLocation} from "react-router-dom";
+import {useTranslation} from "react-i18next";
 
 import * as AccountBackend from "@/backend/AccountBackend";
 import * as Conf from "@/Conf";
@@ -55,6 +56,11 @@ Setting.initCasdoorSdk(Conf.AuthConfig);
 const collapsedKey = "sidebarCollapsed";
 
 export default function App() {
+  // Pages read their labels through i18next.t() at render time rather than the
+  // useTranslation() hook, so subscribing the root to "languageChanged" here
+  // re-renders the whole tree on a language switch. That lets changeLanguage
+  // update every string in place instead of forcing a full window.reload().
+  useTranslation();
   // undefined while the account request is in flight, null when signed out.
   const [account, setAccount] = React.useState<Account | null | undefined>(undefined);
   const [collapsed, setCollapsed] = React.useState(

--- a/web/src/Setting.tsx
+++ b/web/src/Setting.tsx
@@ -199,8 +199,10 @@ export function setLanguage(language: string) {
 }
 
 export function changeLanguage(language: string) {
+  // setLanguage fires i18next's "languageChanged", which the App root listens
+  // for via useTranslation(), so the UI re-translates in place — no page reload
+  // and no lost table filters/pagination.
   setLanguage(language);
-  window.location.reload();
 }
 
 export function isResponseDenied(data: {msg?: string}) {

--- a/web/src/components/charts/ChartCards.tsx
+++ b/web/src/components/charts/ChartCards.tsx
@@ -14,6 +14,7 @@
 
 import * as React from "react";
 import i18next from "i18next";
+import {useTranslation} from "react-i18next";
 import {Bar, BarChart, CartesianGrid, Cell, Pie, PieChart, XAxis, YAxis} from "recharts";
 
 import {Card, CardContent, CardHeader, CardTitle} from "@/components/ui/card";
@@ -80,6 +81,9 @@ export function PieChartCard({
   title: string;
   data: {name: string; value: number}[] | null;
 }) {
+  // Subscribe to language changes so the memoised "Other" label below
+  // re-translates in place on a switch (changeLanguage no longer reloads).
+  const {t} = useTranslation();
   // Rank the slices, keep the five that get their own color, and sum the tail
   // into a single neutral "Other" slice so no color is ever reused.
   const {slices, config} = React.useMemo(() => {
@@ -92,7 +96,7 @@ export function PieChartCard({
 
     if (tail.length > 0) {
       head.push({
-        name: i18next.t("general:Other"),
+        name: t("general:Other"),
         value: tail.reduce((sum, item) => sum + item.value, 0),
         fill: OTHER_COLOR,
       });
@@ -104,7 +108,7 @@ export function PieChartCard({
     });
 
     return {slices: head, config: chartConfig};
-  }, [data]);
+  }, [data, t]);
 
   return (
     <Card className="h-full">


### PR DESCRIPTION
### Summary
Pages read their labels through i18next.t() at render time rather than the useTranslation() hook, so a language change did not re-render them. changeLanguage() worked around this by calling window.location.reload(), which flashed the UI and dropped table filters, pagination, and scroll.

Subscribe the App root to i18next's "languageChanged" via useTranslation() so the whole tree re-translates in place, and drop the reload.