### PR TITLE
fix(channel): block private upstreams in base URL to prevent SSRF

### DIFF
--- a/conf/app.conf
+++ b/conf/app.conf
@@ -31,6 +31,14 @@ gatewayHttpsPort = 443
 ; Optional SOCKS5 proxy ("host:port") for outbound traffic such as ACME.
 httpProxy = ""
 
+; Channel upstream base URLs pointing at a private/loopback/link-local address
+; (or "localhost") are rejected by default, so an authenticated user cannot probe
+; internal services or the cloud metadata endpoint. Operators running a
+; legitimate internal upstream can allow specific hosts back in here, as a
+; comma-separated list of hostnames, IP literals or CIDR blocks, e.g.
+;   allowedPrivateUpstreamHosts = "localhost, 10.0.0.0/8, llm.internal"
+allowedPrivateUpstreamHosts = ""
+
 ; Casdoor is optional. Leave "casdoorEndpoint" empty to sign in against Gateway's
 ; own user table instead, with the built-in "admin" account (password "123").
 ; Filling in all five values below switches sign-in over to Casdoor SSO and

--- a/object/channel.go
+++ b/object/channel.go
@@ -18,11 +18,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
 	"time"
 
+	"github.com/apache/casbin-gateway/conf"
 	"github.com/apache/casbin-gateway/proxy"
 	"github.com/apache/casbin-gateway/util"
 	"github.com/xorm-io/core"
@@ -195,10 +197,89 @@ func validateBaseUrl(baseUrl string) error {
 	if u.Scheme != "http" && u.Scheme != "https" {
 		return fmt.Errorf("invalid base URL: only the http and https schemes are supported")
 	}
-	if u.Hostname() == "" {
+	host := u.Hostname()
+	if host == "" {
 		return fmt.Errorf("invalid base URL: the host is empty")
 	}
+	if err := validateUpstreamHost(host); err != nil {
+		return err
+	}
 	return nil
+}
+
+// validateUpstreamHost rejects hosts that point at the gateway's own machine or
+// its private network, so an authenticated user cannot turn the channel probe
+// (or a saved channel) into an SSRF against internal services: loopback, the
+// RFC 1918 ranges, IPv6 unique-local addresses and — most importantly — the
+// 169.254.169.254 cloud metadata endpoint that leaks instance credentials.
+//
+// Operators that legitimately run an internal upstream (a self-hosted vLLM or
+// one-api, say) can allow specific hosts back in via the
+// allowedPrivateUpstreamHosts setting; see hostAllowlisted.
+//
+// It is a static check on the literal host: an IP literal is inspected
+// directly and "localhost" is rejected by name. It deliberately does not
+// resolve DNS, so a public hostname that resolves to a private address (for
+// example via DNS rebinding) is not caught here — closing that hole requires
+// validating the address again at dial time.
+func validateUpstreamHost(host string) error {
+	ip := net.ParseIP(host)
+
+	if hostAllowlisted(host, ip) {
+		return nil
+	}
+
+	if strings.EqualFold(host, "localhost") || strings.HasSuffix(strings.ToLower(host), ".localhost") {
+		return fmt.Errorf("invalid base URL: the host %q is not allowed", host)
+	}
+	if ip == nil {
+		// A regular hostname; leave address-based checks to dial time.
+		return nil
+	}
+	if !isPublicIP(ip) {
+		return fmt.Errorf("invalid base URL: the host %q is not a public address", host)
+	}
+	return nil
+}
+
+// hostAllowlisted reports whether host has been explicitly permitted as an
+// internal upstream through the allowedPrivateUpstreamHosts setting. Entries are
+// comma- or whitespace-separated and may be a hostname ("localhost",
+// "llm.internal"), an IP literal ("10.0.0.5") or a CIDR block ("10.0.0.0/8").
+// The setting is read on each call so a config reload takes effect without a
+// restart. ip is the parsed form of host, or nil when host is not an IP literal.
+func hostAllowlisted(host string, ip net.IP) bool {
+	raw := strings.Trim(conf.GetConfigString("allowedPrivateUpstreamHosts"), `"' `)
+	if raw == "" {
+		return false
+	}
+
+	for _, entry := range strings.FieldsFunc(raw, func(r rune) bool { return r == ',' || r == ' ' }) {
+		if _, cidr, err := net.ParseCIDR(entry); err == nil {
+			if ip != nil && cidr.Contains(ip) {
+				return true
+			}
+			continue
+		}
+		if strings.EqualFold(entry, host) {
+			return true
+		}
+	}
+	return false
+}
+
+// isPublicIP reports whether ip is safe to reach out to, i.e. it is not a
+// loopback, unspecified, private, link-local, multicast or broadcast address.
+func isPublicIP(ip net.IP) bool {
+	if ip.IsLoopback() || ip.IsUnspecified() || ip.IsPrivate() ||
+		ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsMulticast() {
+		return false
+	}
+	// The IPv4 limited-broadcast address is not covered by the checks above.
+	if v4 := ip.To4(); v4 != nil && v4.Equal(net.IPv4bcast) {
+		return false
+	}
+	return true
 }
 
 // BuildOpenAiUrl joins an OpenAI-compatible endpoint onto a channel base URL.

--- a/object/channel_test.go
+++ b/object/channel_test.go
@@ -1,0 +1,97 @@
+// Copyright 2026 The casbin Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package object
+
+import "testing"
+
+func TestValidateBaseUrl(t *testing.T) {
+	tests := []struct {
+		name    string
+		baseUrl string
+		wantErr bool
+	}{
+		// Valid public upstreams.
+		{"public https", "https://api.openai.com/v1", false},
+		{"public http", "http://api.deepseek.com/v1", false},
+		{"public hostname with port", "https://oneapi.example.com:8080", false},
+		{"public ip literal", "https://8.8.8.8/v1", false},
+
+		// Scheme and host validation.
+		{"empty", "", true},
+		{"missing scheme", "api.openai.com/v1", true},
+		{"unsupported scheme", "ftp://api.openai.com", true},
+		{"file scheme", "file:///etc/passwd", true},
+
+		// SSRF: loopback / localhost.
+		{"localhost", "http://localhost/v1", true},
+		{"localhost uppercase", "http://LOCALHOST/v1", true},
+		{"localhost subdomain", "http://foo.localhost/v1", true},
+		{"loopback ipv4", "http://127.0.0.1/v1", true},
+		{"loopback ipv4 alt", "http://127.9.9.9:8080", true},
+		{"loopback ipv6", "http://[::1]/v1", true},
+
+		// SSRF: cloud metadata / link-local.
+		{"metadata endpoint", "http://169.254.169.254/latest/meta-data", true},
+		{"link-local ipv6", "http://[fe80::1]/v1", true},
+
+		// SSRF: private ranges.
+		{"rfc1918 10", "http://10.0.0.1/v1", true},
+		{"rfc1918 172", "http://172.16.5.4/v1", true},
+		{"rfc1918 192", "https://192.168.1.1/v1", true},
+		{"ipv6 unique local", "http://[fc00::1]/v1", true},
+
+		// SSRF: unspecified / broadcast.
+		{"unspecified", "http://0.0.0.0/v1", true},
+		{"broadcast", "http://255.255.255.255/v1", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateBaseUrl(tt.baseUrl)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("validateBaseUrl(%q) error = %v, wantErr = %v", tt.baseUrl, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateBaseUrl_Allowlist(t *testing.T) {
+	tests := []struct {
+		name      string
+		allowlist string
+		baseUrl   string
+		wantErr   bool
+	}{
+		{"exact ip allowed", "10.0.0.5", "http://10.0.0.5/v1", false},
+		{"exact ip does not allow others", "10.0.0.5", "http://10.0.0.6/v1", true},
+		{"cidr allows range", "192.168.0.0/16", "http://192.168.1.1/v1", false},
+		{"cidr does not allow outside", "192.168.0.0/16", "http://10.0.0.1/v1", true},
+		{"localhost by name", "localhost", "http://localhost/v1", false},
+		{"comma separated list", "127.0.0.1, 10.0.0.0/8", "http://10.1.2.3/v1", false},
+		{"space separated list", "127.0.0.1 10.0.0.0/8", "http://127.0.0.1/v1", false},
+		{"allowlist does not weaken scheme check", "10.0.0.5", "ftp://10.0.0.5", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// conf.GetConfigString reads env vars first, so this overrides the setting.
+			t.Setenv("allowedPrivateUpstreamHosts", tt.allowlist)
+			err := validateBaseUrl(tt.baseUrl)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("validateBaseUrl(%q) with allowlist %q error = %v, wantErr = %v", tt.baseUrl, tt.allowlist, err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Summary

validateBaseUrl now rejects channel base URLs whose host points at a loopback, unspecified, private (RFC 1918 / IPv6 ULA), link-local or broadcast address, or "localhost". This stops an authenticated user from using the channel probe (or a saved channel) to reach internal services or the 169.254.169.254 cloud metadata endpoint.

Operators that run a legitimate internal upstream can allow specific hosts, IP literals or CIDR blocks back in via the new allowedPrivateUpstreamHosts setting.

The check is applied on both the save and test paths, since both go through validateBaseUrl.