### PR TITLE
feat(channel): test connectivity against unsaved edits

### DIFF
--- a/controllers/channel.go
+++ b/controllers/channel.go
@@ -212,25 +212,21 @@ func (c *ApiController) TestChannel() {
 		return
 	}
 
-	var request struct {
-		Owner string `json:"owner"`
-		Name  string `json:"name"`
-	}
-	if err := json.Unmarshal(c.Ctx.Input.RequestBody, &request); err != nil {
+	var channel object.Channel
+	if err := json.Unmarshal(c.Ctx.Input.RequestBody, &channel); err != nil {
 		c.ResponseError(err.Error())
 		return
 	}
 
-	if request.Owner == "" || request.Name == "" {
+	if channel.Owner == "" || channel.Name == "" {
 		c.ResponseError("the channel owner and name cannot be empty")
 		return
 	}
-	if !c.channelAccess(request.Owner) {
+	if !c.channelAccess(channel.Owner) {
 		c.ResponseError("unauthorized")
 		return
 	}
 
-	channel := &object.Channel{Owner: request.Owner, Name: request.Name}
-	success, statusCode, message := object.TestChannelConnectivity(channel)
+	success, statusCode, message := object.TestChannelConnectivity(&channel)
 	c.ResponseOk(map[string]interface{}{"success": success, "statusCode": statusCode, "message": message})
 }

--- a/object/channel.go
+++ b/object/channel.go
@@ -269,29 +269,37 @@ func DeleteChannel(channel *Channel) (bool, error) {
 }
 
 // TestChannelConnectivity performs a read-only probe against the channel's
-// upstream. It returns whether the probe succeeded, the upstream HTTP status
-// code (0 when no response was received) and a human-readable message.
+// upstream. It probes the configuration passed in (which may be unsaved edits
+// from the editor), so the user can verify a channel before deciding to save.
+// It returns whether the probe succeeded, the upstream HTTP status code (0 when
+// no response was received) and a human-readable message.
 func TestChannelConnectivity(channel *Channel) (bool, int, string) {
-	stored, err := getChannel(channel.Owner, channel.Name)
-	if err != nil {
-		return false, 0, err.Error()
-	}
-	if stored == nil {
-		return false, 0, "the channel does not exist"
+	// The browser only ever sees the masked key, so getting it back means the
+	// user did not touch the field. Fall back to the stored (decrypted) key so
+	// an unchanged key can still be tested without re-entering it.
+	if channel.ApiKey == ApiKeyMask {
+		stored, err := getChannel(channel.Owner, channel.Name)
+		if err != nil {
+			return false, 0, err.Error()
+		}
+		if stored == nil {
+			return false, 0, "the channel does not exist"
+		}
+		channel.ApiKey = stored.ApiKey
 	}
 
-	if !IsChannelTypeSupported(stored) {
-		return false, 0, fmt.Sprintf("the %s channel type is not supported", stored.Type)
+	if !IsChannelTypeSupported(channel) {
+		return false, 0, fmt.Sprintf("the %s channel type is not supported", channel.Type)
 	}
 
-	if stored.BaseUrl == "" {
+	if channel.BaseUrl == "" {
 		return false, 0, "the base URL is empty"
 	}
-	if err = validateBaseUrl(stored.BaseUrl); err != nil {
+	if err := validateBaseUrl(channel.BaseUrl); err != nil {
 		return false, 0, err.Error()
 	}
 
-	probeUrl, err := BuildOpenAiUrl(stored.BaseUrl, "/models")
+	probeUrl, err := BuildOpenAiUrl(channel.BaseUrl, "/models")
 	if err != nil {
 		return false, 0, err.Error()
 	}
@@ -300,8 +308,8 @@ func TestChannelConnectivity(channel *Channel) (bool, int, string) {
 	if err != nil {
 		return false, 0, err.Error()
 	}
-	if stored.ApiKey != "" {
-		req.Header.Set("Authorization", "Bearer "+stored.ApiKey)
+	if channel.ApiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+channel.ApiKey)
 	}
 
 	client := &http.Client{

--- a/web/src/backend/ChannelBackend.ts
+++ b/web/src/backend/ChannelBackend.ts
@@ -49,6 +49,6 @@ export function deleteChannel(channel: Channel) {
   return request("/api/delete-channel", "POST", channel);
 }
 
-export function testChannel(owner: string, name: string) {
-  return request<ChannelTestResult>("/api/test-channel", "POST", {owner: owner, name: name});
+export function testChannel(channel: Channel) {
+  return request<ChannelTestResult>("/api/test-channel", "POST", channel);
 }

--- a/web/src/pages/ChannelEditPage.tsx
+++ b/web/src/pages/ChannelEditPage.tsx
@@ -119,9 +119,13 @@ export default function ChannelEditPage() {
   };
 
   const test = () => {
+    if (!channel) {
+      return;
+    }
+
     setTesting(true);
     setResult(null);
-    ChannelBackend.testChannel(owner, channelName)
+    ChannelBackend.testChannel(channel)
       .then(res => {
         setTesting(false);
         if (res.status === "error") {


### PR DESCRIPTION
### Summary
The channel editor's "Test Connectivity" button probed the saved channel, so unsaved changes to the base URL or API key were ignored and users had to save before a test could reflect their edits. It now tests the configuration currently in the form, letting users verify a channel before deciding whether to save. An unchanged (masked) API key still falls back to the stored key.