### PR TITLE
fix(agent): detect Windows agents under a custom npm prefix

### DIFF
--- a/agent/scan_common.go
+++ b/agent/scan_common.go
@@ -79,6 +79,44 @@ func (f *Fingerprint) npmPackagePath() string {
 	return filepath.FromSlash(f.NpmPackage)
 }
 
+// npmrcPrefix returns the "prefix" setting from an npmrc file, or "" when the
+// file is absent or sets no prefix. npm lets users relocate the global install
+// root this way (npm config set prefix ...), so discovery must read it to find
+// agents installed outside the default layout. Only the prefix key matters; the
+// rest of the npm config is ignored. Any ${VAR} references are expanded the way
+// npm expands them.
+func npmrcPrefix(path string) string {
+	info, err := os.Stat(path)
+	if err != nil || !info.Mode().IsRegular() || info.Size() > maxPackageJSONSize {
+		return ""
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, ";") || strings.HasPrefix(line, "#") {
+			continue
+		}
+		key, value, ok := strings.Cut(line, "=")
+		if !ok || strings.TrimSpace(key) != "prefix" {
+			continue
+		}
+		value = strings.TrimSpace(value)
+		value = strings.Trim(value, `"'`)
+		return os.Expand(value, npmConfigEnv)
+	}
+	return ""
+}
+
+// npmConfigEnv resolves ${VAR} references in npmrc values against the
+// environment, matching npm's own expansion. An undefined variable expands to
+// the empty string, again as npm does.
+func npmConfigEnv(name string) string {
+	return os.Getenv(name)
+}
+
 func stampAgentId(installations []Installation, mark int, agentId string) {
 	for i := mark; i < len(installations); i++ {
 		installations[i].AgentId = agentId

--- a/agent/scan_common_test.go
+++ b/agent/scan_common_test.go
@@ -1,0 +1,56 @@
+// Copyright 2025 The casbin Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNpmrcPrefix(t *testing.T) {
+	t.Setenv("CASBIN_NPMRC_TEST_HOME", `D:\develop`)
+
+	tests := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{name: "plain", content: "prefix=D:\\develop\\npmPackage", want: `D:\develop\npmPackage`},
+		{name: "spaces and quotes", content: `prefix = "D:\develop\npmPackage"`, want: `D:\develop\npmPackage`},
+		{name: "ignores comments and other keys", content: "; comment\nregistry=https://example.com\nprefix=/opt/npm\n", want: "/opt/npm"},
+		{name: "env expansion", content: "prefix=${CASBIN_NPMRC_TEST_HOME}\\npmPackage", want: `D:\develop\npmPackage`},
+		{name: "no prefix set", content: "registry=https://example.com\n", want: ""},
+		{name: "empty file", content: "", want: ""},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), ".npmrc")
+			if err := os.WriteFile(path, []byte(test.content), 0o600); err != nil {
+				t.Fatalf("write npmrc: %v", err)
+			}
+			if got := npmrcPrefix(path); got != test.want {
+				t.Errorf("npmrcPrefix() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestNpmrcPrefixMissingFile(t *testing.T) {
+	if got := npmrcPrefix(filepath.Join(t.TempDir(), "does-not-exist")); got != "" {
+		t.Errorf("npmrcPrefix() = %q, want empty for missing file", got)
+	}
+}

--- a/agent/scan_windows.go
+++ b/agent/scan_windows.go
@@ -329,5 +329,44 @@ func scanWindowsNpm(ctx context.Context, fingerprint *Fingerprint, home homeDir)
 	for _, dir := range fingerprint.ExtraWindowsNpmDirs {
 		patterns = append(patterns, filepath.Join(local, filepath.FromSlash(dir), "node_modules", pkg, "package.json"))
 	}
+	// A user may relocate npm's global root with a custom prefix (e.g.
+	// D:\develop\npmPackage), which falls outside every fixed layout above.
+	for _, prefix := range windowsNpmPrefixDirs(home) {
+		patterns = append(patterns,
+			filepath.Join(prefix, "node_modules", pkg, "package.json"),
+			filepath.Join(prefix, "lib", "node_modules", pkg, "package.json"),
+		)
+	}
 	return scanNpmPatterns(ctx, fingerprint, patterns, home.owner, nil)
+}
+
+// windowsNpmPrefixDirs returns npm global prefixes configured outside the
+// default layout, so an agent installed under a custom prefix is still found.
+// It reads the npm_config_prefix environment variable (current user only) and
+// the "prefix" setting in the profile's .npmrc.
+func windowsNpmPrefixDirs(home homeDir) []string {
+	var dirs []string
+	seen := map[string]bool{}
+	add := func(prefix string) {
+		if strings.TrimSpace(prefix) == "" {
+			return
+		}
+		prefix = filepath.Clean(prefix)
+		key := strings.ToLower(prefix)
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		dirs = append(dirs, prefix)
+	}
+
+	// The environment only describes the process's own user, so it is read for
+	// the current home; other profiles are covered by their on-disk .npmrc.
+	if current, err := os.UserHomeDir(); err == nil &&
+		strings.EqualFold(filepath.Clean(current), filepath.Clean(home.path)) {
+		add(os.Getenv("npm_config_prefix"))
+		add(os.Getenv("NPM_CONFIG_PREFIX"))
+	}
+	add(npmrcPrefix(filepath.Join(home.path, ".npmrc")))
+	return dirs
 }


### PR DESCRIPTION
### Summary
The Windows probe only scanned fixed npm layouts, so an agent installed under a relocated global prefix (npm config set prefix, e.g. D:\develop\npmPackage) was never found and showed up as "not installed" even when present. The probe now also reads the npm prefix from the npm_config_prefix environment variable and the profile's .npmrc, so agents under a custom prefix are discovered like any other install.