### PR TITLE
feat(agentconfig): write a selected provider into each CLI agent config

### DIFF
--- a/agentconfig/atomic.go
+++ b/agentconfig/atomic.go
@@ -1,0 +1,78 @@
+// Copyright 2026 The casbin Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agentconfig
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// writeFileAtomic writes data to path by creating a temporary file in the same
+// directory, fsyncing it, then renaming it over path. A crash or power loss can
+// therefore never leave a half-written config: path always contains either the
+// old file or the complete new one. The parent directory is fsynced so the
+// rename itself survives a crash, and mode is applied to the final file.
+//
+// The temp file must share path's directory so the rename stays on one
+// filesystem and is atomic; a rename across filesystems is a copy and is not.
+func writeFileAtomic(path string, data []byte, mode os.FileMode) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+
+	tmp, err := os.CreateTemp(dir, ".casbin-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	// Remove the temp file if anything below fails; a no-op once the rename has
+	// consumed it.
+	defer os.Remove(tmpName)
+
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Chmod(mode); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+
+	if err := os.Rename(tmpName, path); err != nil {
+		return err
+	}
+	fsyncDir(dir)
+	return nil
+}
+
+// fsyncDir flushes a directory entry so a rename into it is durable. It is
+// best-effort: several platforms and filesystems cannot sync a directory, and
+// that must not fail an otherwise successful write.
+func fsyncDir(dir string) {
+	d, err := os.Open(dir)
+	if err != nil {
+		return
+	}
+	defer d.Close()
+	_ = d.Sync()
+}

--- a/agentconfig/atomic_test.go
+++ b/agentconfig/atomic_test.go
@@ -1,0 +1,74 @@
+// Copyright 2026 The casbin Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agentconfig
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestWriteFileAtomicCreatesFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nested", "config.json")
+	if err := writeFileAtomic(path, []byte("hello"), 0o600); err != nil {
+		t.Fatalf("writeFileAtomic: %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if string(got) != "hello" {
+		t.Errorf("content = %q, want %q", got, "hello")
+	}
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("stat: %v", err)
+		}
+		if info.Mode().Perm() != 0o600 {
+			t.Errorf("mode = %v, want 0600", info.Mode().Perm())
+		}
+	}
+}
+
+func TestWriteFileAtomicOverwritesAndLeavesNoTemp(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	if err := os.WriteFile(path, []byte("old"), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	if err := writeFileAtomic(path, []byte("new"), 0o600); err != nil {
+		t.Fatalf("writeFileAtomic: %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if string(got) != "new" {
+		t.Errorf("content = %q, want %q", got, "new")
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read dir: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Errorf("directory has %d entries, want 1 (temp file left behind)", len(entries))
+	}
+}

--- a/agentconfig/claude_code.go
+++ b/agentconfig/claude_code.go
@@ -1,0 +1,65 @@
+// Copyright 2026 The casbin Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agentconfig
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/apache/casbin-gateway/agentpatch"
+)
+
+// claudeCode writes the selected provider into ~/.claude/settings.json. Claude
+// Code reads its upstream and credentials from the "env" object there, so a
+// switch is a matter of setting a handful of ANTHROPIC_* keys and leaving the
+// rest of the file (hooks, permissions, other env) untouched.
+type claudeCode struct{}
+
+func init() { register(claudeCode{}) }
+
+func (claudeCode) AgentID() string { return "claude-code" }
+
+func (claudeCode) DefaultMode() os.FileMode { return 0o600 }
+
+func (claudeCode) ConfigPath(install Install) (string, error) {
+	home, err := agentpatch.HomeOf(install.Owner)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".claude", "settings.json"), nil
+}
+
+func (claudeCode) Render(existing []byte, p Provider) ([]byte, error) {
+	doc, err := loadJSONObject(existing)
+	if err != nil {
+		return nil, err
+	}
+
+	env := ensureObject(doc, "env")
+	setOrDelete(env, "ANTHROPIC_BASE_URL", p.BaseURL)
+	setOrDelete(env, "ANTHROPIC_AUTH_TOKEN", p.APIKey)
+	setOrDelete(env, "ANTHROPIC_DEFAULT_OPUS_MODEL", p.Models[RoleOpus])
+	setOrDelete(env, "ANTHROPIC_DEFAULT_SONNET_MODEL", p.Models[RoleSonnet])
+	setOrDelete(env, "ANTHROPIC_DEFAULT_HAIKU_MODEL", p.Models[RoleHaiku])
+
+	// TODO(pr1-followup): pass Provider.Extra through into env, refusing to
+	// overwrite the owned keys above so a provider preset cannot silently change
+	// the base URL or token from a stray Extra entry.
+
+	// An emptied env object is left in place rather than removed: Claude Code
+	// treats a missing and an empty "env" the same, and keeping it avoids a
+	// spurious diff when every owned key was cleared.
+	return marshalJSONObject(doc)
+}

--- a/agentconfig/claude_code_test.go
+++ b/agentconfig/claude_code_test.go
@@ -1,0 +1,94 @@
+// Copyright 2026 The casbin Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agentconfig
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestClaudeCodeRenderCreatesEnv(t *testing.T) {
+	out, err := claudeCode{}.Render(nil, Provider{
+		BaseURL: "https://api.deepseek.com/anthropic",
+		APIKey:  "sk-test",
+		Models:  map[Role]string{RoleOpus: "deepseek-v4-pro"},
+	})
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+
+	env := decodeEnv(t, out)
+	if env["ANTHROPIC_BASE_URL"] != "https://api.deepseek.com/anthropic" {
+		t.Errorf("ANTHROPIC_BASE_URL = %q", env["ANTHROPIC_BASE_URL"])
+	}
+	if env["ANTHROPIC_AUTH_TOKEN"] != "sk-test" {
+		t.Errorf("ANTHROPIC_AUTH_TOKEN = %q", env["ANTHROPIC_AUTH_TOKEN"])
+	}
+	if env["ANTHROPIC_DEFAULT_OPUS_MODEL"] != "deepseek-v4-pro" {
+		t.Errorf("ANTHROPIC_DEFAULT_OPUS_MODEL = %q", env["ANTHROPIC_DEFAULT_OPUS_MODEL"])
+	}
+}
+
+func TestClaudeCodeRenderPreservesUnrelatedKeys(t *testing.T) {
+	existing := []byte(`{
+  "hooks": {"Stop": [{"hooks": []}]},
+  "env": {"MY_OWN": "keep", "ANTHROPIC_BASE_URL": "https://old.example.com"}
+}`)
+
+	out, err := claudeCode{}.Render(existing, Provider{BaseURL: "https://new.example.com"})
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+
+	var doc map[string]any
+	if err := json.Unmarshal(out, &doc); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if _, ok := doc["hooks"]; !ok {
+		t.Error("hooks was dropped; unrelated keys must be preserved")
+	}
+	env, _ := doc["env"].(map[string]any)
+	if env["MY_OWN"] != "keep" {
+		t.Errorf("unrelated env key MY_OWN = %v, want kept", env["MY_OWN"])
+	}
+	if env["ANTHROPIC_BASE_URL"] != "https://new.example.com" {
+		t.Errorf("ANTHROPIC_BASE_URL = %v, want overwritten", env["ANTHROPIC_BASE_URL"])
+	}
+}
+
+func TestClaudeCodeRenderClearsUnsetFields(t *testing.T) {
+	existing := []byte(`{"env": {"ANTHROPIC_AUTH_TOKEN": "sk-stale"}}`)
+
+	out, err := claudeCode{}.Render(existing, Provider{BaseURL: "https://new.example.com"})
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+
+	env := decodeEnv(t, out)
+	if _, ok := env["ANTHROPIC_AUTH_TOKEN"]; ok {
+		t.Error("stale ANTHROPIC_AUTH_TOKEN was not cleared for an empty provider APIKey")
+	}
+}
+
+func decodeEnv(t *testing.T, data []byte) map[string]string {
+	t.Helper()
+	var doc struct {
+		Env map[string]string `json:"env"`
+	}
+	if err := json.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	return doc.Env
+}

--- a/agentconfig/codex.go
+++ b/agentconfig/codex.go
@@ -1,0 +1,70 @@
+// Copyright 2026 The casbin Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agentconfig
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/apache/casbin-gateway/agentpatch"
+)
+
+// codex writes the selected provider into ~/.codex/config.toml. Codex selects
+// its upstream with a top-level model_provider key pointing at a table under
+// [model_providers]. For a custom provider the only file-based way to supply a
+// credential is experimental_bearer_token on that table (env_key merely names
+// an environment variable Codex reads at runtime, which Gateway cannot set for
+// a separately launched process), so the key is written there directly.
+type codex struct{}
+
+func init() { register(codex{}) }
+
+func (codex) AgentID() string { return "codex" }
+
+func (codex) DefaultMode() os.FileMode { return 0o600 }
+
+func (codex) ConfigPath(install Install) (string, error) {
+	home, err := agentpatch.HomeOf(install.Owner)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".codex", "config.toml"), nil
+}
+
+func (codex) Render(existing []byte, p Provider) ([]byte, error) {
+	doc, err := loadTOML(existing)
+	if err != nil {
+		return nil, err
+	}
+
+	doc["model_provider"] = p.ID
+
+	providers := ensureTOMLTable(doc, "model_providers")
+	entry := ensureTOMLTable(providers, p.ID)
+	entry["name"] = p.Name
+	entry["base_url"] = p.BaseURL
+	entry["wire_api"] = "chat"
+	// experimental_bearer_token is mutually exclusive with env_key, so any
+	// env_key a previous write left is removed. An empty key clears the token
+	// rather than persisting an empty string.
+	setOrDelete(entry, "experimental_bearer_token", p.APIKey)
+	delete(entry, "env_key")
+
+	if model := p.Models[RoleDefault]; model != "" {
+		doc["model"] = model
+	}
+
+	return marshalTOML(doc)
+}

--- a/agentconfig/codex_test.go
+++ b/agentconfig/codex_test.go
@@ -1,0 +1,128 @@
+// Copyright 2026 The casbin Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agentconfig
+
+import (
+	"testing"
+
+	toml "github.com/pelletier/go-toml/v2"
+)
+
+func TestCodexRenderSelectsProvider(t *testing.T) {
+	out, err := codex{}.Render(nil, Provider{
+		ID:      "deepseek",
+		Name:    "DeepSeek",
+		BaseURL: "https://api.deepseek.com/v1",
+		APIKey:  "sk-secret",
+		Models:  map[Role]string{RoleDefault: "deepseek-chat"},
+	})
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+
+	doc := decodeTOML(t, out)
+	if doc["model_provider"] != "deepseek" {
+		t.Errorf("model_provider = %v, want deepseek", doc["model_provider"])
+	}
+	if doc["model"] != "deepseek-chat" {
+		t.Errorf("model = %v, want deepseek-chat", doc["model"])
+	}
+	entry := providerEntry(t, doc, "deepseek")
+	if entry["base_url"] != "https://api.deepseek.com/v1" {
+		t.Errorf("base_url = %v", entry["base_url"])
+	}
+	if entry["experimental_bearer_token"] != "sk-secret" {
+		t.Errorf("experimental_bearer_token = %v, want the provider key", entry["experimental_bearer_token"])
+	}
+}
+
+func TestCodexRenderReplacesEnvKeyWithBearerToken(t *testing.T) {
+	// A config previously written with env_key must not keep it, since Codex
+	// treats env_key and experimental_bearer_token as mutually exclusive.
+	existing := []byte("model_provider = \"deepseek\"\n\n[model_providers.deepseek]\nname = \"DeepSeek\"\nbase_url = \"https://api.deepseek.com/v1\"\nenv_key = \"CASBIN_DEEPSEEK_API_KEY\"\n")
+
+	out, err := codex{}.Render(existing, Provider{ID: "deepseek", Name: "DeepSeek", BaseURL: "https://api.deepseek.com/v1", APIKey: "sk-secret"})
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+
+	entry := providerEntry(t, decodeTOML(t, out), "deepseek")
+	if _, ok := entry["env_key"]; ok {
+		t.Error("env_key was kept alongside experimental_bearer_token")
+	}
+	if entry["experimental_bearer_token"] != "sk-secret" {
+		t.Errorf("experimental_bearer_token = %v", entry["experimental_bearer_token"])
+	}
+}
+
+func TestCodexRenderClearsTokenWhenKeyEmpty(t *testing.T) {
+	existing := []byte("[model_providers.deepseek]\nexperimental_bearer_token = \"sk-old\"\n")
+
+	out, err := codex{}.Render(existing, Provider{ID: "deepseek", Name: "DeepSeek", BaseURL: "https://api.deepseek.com/v1"})
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+
+	entry := providerEntry(t, decodeTOML(t, out), "deepseek")
+	if _, ok := entry["experimental_bearer_token"]; ok {
+		t.Error("stale experimental_bearer_token was not cleared for an empty key")
+	}
+}
+
+func TestCodexRenderPreservesUnrelatedTables(t *testing.T) {
+	existing := []byte("model_provider = \"old\"\n\n[tui]\ntheme = \"dark\"\n\n[model_providers.old]\nbase_url = \"https://old.example.com\"\n")
+
+	out, err := codex{}.Render(existing, Provider{ID: "new", Name: "New", BaseURL: "https://new.example.com"})
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+
+	doc := decodeTOML(t, out)
+	if doc["model_provider"] != "new" {
+		t.Errorf("model_provider = %v, want new", doc["model_provider"])
+	}
+	tui, ok := doc["tui"].(map[string]any)
+	if !ok || tui["theme"] != "dark" {
+		t.Errorf("unrelated [tui] table not preserved: %v", doc["tui"])
+	}
+	// The previously selected provider's table is left in place; only the
+	// pointer moved.
+	if _, ok := providerTable(doc)["old"]; !ok {
+		t.Error("previous provider table was dropped")
+	}
+}
+
+func decodeTOML(t *testing.T, data []byte) map[string]any {
+	t.Helper()
+	var doc map[string]any
+	if err := toml.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("unmarshal toml: %v", err)
+	}
+	return doc
+}
+
+func providerTable(doc map[string]any) map[string]any {
+	providers, _ := doc["model_providers"].(map[string]any)
+	return providers
+}
+
+func providerEntry(t *testing.T, doc map[string]any, id string) map[string]any {
+	t.Helper()
+	entry, ok := providerTable(doc)[id].(map[string]any)
+	if !ok {
+		t.Fatalf("provider entry %q missing", id)
+	}
+	return entry
+}

--- a/agentconfig/jsondoc.go
+++ b/agentconfig/jsondoc.go
@@ -1,0 +1,73 @@
+// Copyright 2026 The casbin Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agentconfig
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// loadJSONObject parses a JSON object, returning an empty map for an absent or
+// blank file so callers can create one. A non-object root is an error rather
+// than silently discarded, since overwriting it would destroy user data.
+func loadJSONObject(existing []byte) (map[string]any, error) {
+	if len(bytes.TrimSpace(existing)) == 0 {
+		return map[string]any{}, nil
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(existing, &doc); err != nil {
+		return nil, fmt.Errorf("parse config: %w", err)
+	}
+	if doc == nil {
+		return nil, fmt.Errorf("parse config: root must be a JSON object")
+	}
+	return doc, nil
+}
+
+// marshalJSONObject renders doc with two-space indentation and a trailing
+// newline, matching the formatting agent tools write themselves. Map keys are
+// sorted by encoding/json, so the output is deterministic.
+func marshalJSONObject(doc map[string]any) ([]byte, error) {
+	data, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return append(data, '\n'), nil
+}
+
+// ensureObject returns the nested object at key, creating an empty one when the
+// key is absent. A non-object value at key is replaced, because the adapter owns
+// that slot (e.g. Claude Code's "env").
+func ensureObject(doc map[string]any, key string) map[string]any {
+	if nested, ok := doc[key].(map[string]any); ok {
+		return nested
+	}
+	nested := map[string]any{}
+	doc[key] = nested
+	return nested
+}
+
+// setOrDelete sets key to value, or deletes it when value is empty, so an
+// unset provider field clears the stale entry instead of leaving the previous
+// provider's value behind.
+func setOrDelete(obj map[string]any, key, value string) {
+	if strings.TrimSpace(value) == "" {
+		delete(obj, key)
+		return
+	}
+	obj[key] = value
+}

--- a/agentconfig/switch.go
+++ b/agentconfig/switch.go
@@ -1,0 +1,186 @@
+// Copyright 2026 The casbin Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package agentconfig writes a selected upstream provider into the native
+// configuration file of each supported CLI agent (Claude Code, Codex, ...),
+// atomically and idempotently. Each agent's format mapping is a pure Adapter;
+// this file owns reading, the one-time backup and the atomic write, so an
+// Adapter never touches the filesystem itself.
+package agentconfig
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+)
+
+// Install identifies one discovered CLI agent installation to write into. The
+// fields mirror what agentpatch already resolves during discovery; they are
+// kept local so this package does not depend on the monitoring code path.
+type Install struct {
+	AgentID string
+	Path    string
+	Owner   string
+}
+
+// Role selects which model slot a provider model maps to. Adapters that have no
+// notion of roles ignore the ones they do not use.
+type Role string
+
+const (
+	RoleDefault Role = "default"
+	RoleOpus    Role = "opus"
+	RoleSonnet  Role = "sonnet"
+	RoleHaiku   Role = "haiku"
+)
+
+// Provider is the upstream selection to write into an agent's own config, in
+// whatever format that agent expects. Adapters map these neutral fields onto
+// the agent's schema; an empty field is left to the adapter's default handling
+// (typically: remove the key it owns).
+type Provider struct {
+	ID      string            // stable id, e.g. the channel name
+	Name    string            // display name
+	BaseURL string            // upstream base URL
+	APIKey  string            // secret; the adapter decides file vs env placement
+	Models  map[Role]string   // optional per-role model overrides
+	Extra   map[string]string // optional adapter-specific passthrough
+}
+
+// Adapter is one agent's format mapping. Render is a pure transform: given the
+// current file bytes it returns the new bytes with only the adapter's own
+// fields rewritten and everything else preserved. It performs no I/O.
+type Adapter interface {
+	AgentID() string
+	// ConfigPath returns the agent's own config file for this install. It may
+	// read the environment and account home, but must not write.
+	ConfigPath(install Install) (string, error)
+	// Render returns the updated file contents. existing is nil when the config
+	// file does not exist yet.
+	Render(existing []byte, p Provider) ([]byte, error)
+	// DefaultMode is the permission for a freshly created config file.
+	DefaultMode() os.FileMode
+}
+
+// Result describes what Switch did so callers can distinguish a real write from
+// an idempotent no-op.
+type Result struct {
+	AgentID    string
+	ConfigPath string
+	Changed    bool // false when the config already matched the provider
+	BackedUp   bool // true when a one-time pre-Gateway backup was created
+}
+
+var adapters = map[string]Adapter{}
+
+func register(a Adapter) { adapters[a.AgentID()] = a }
+
+// SupportedAgents reports the agent ids that can be switched.
+func SupportedAgents() []string {
+	ids := make([]string, 0, len(adapters))
+	for id := range adapters {
+		ids = append(ids, id)
+	}
+	return ids
+}
+
+// Switch writes provider p into install's config file, atomically and
+// idempotently: switching again to the same provider is a no-op, and switching
+// to a different one rewrites only the adapter-owned fields while preserving
+// every unrelated user setting.
+func Switch(install Install, p Provider) (Result, error) {
+	adapter, err := adapterFor(install.AgentID)
+	if err != nil {
+		return Result{}, err
+	}
+
+	path, err := adapter.ConfigPath(install)
+	if err != nil {
+		return Result{}, err
+	}
+
+	existing, err := readFileOrNil(path)
+	if err != nil {
+		return Result{}, err
+	}
+
+	updated, err := adapter.Render(existing, p)
+	if err != nil {
+		return Result{}, err
+	}
+
+	result := Result{AgentID: install.AgentID, ConfigPath: path}
+	if existing != nil && bytes.Equal(existing, updated) {
+		return result, nil // already selected; nothing to write
+	}
+
+	backedUp, err := backupOnce(path, existing)
+	if err != nil {
+		return Result{}, err
+	}
+	result.BackedUp = backedUp
+
+	mode := adapter.DefaultMode()
+	if info, err := os.Stat(path); err == nil {
+		mode = info.Mode().Perm()
+	}
+	if err := writeFileAtomic(path, updated, mode); err != nil {
+		return Result{}, err
+	}
+	result.Changed = true
+	return result, nil
+}
+
+func adapterFor(id string) (Adapter, error) {
+	if id == "" {
+		return nil, errors.New("agentId is required")
+	}
+	adapter, ok := adapters[id]
+	if !ok {
+		return nil, fmt.Errorf("unknown agent %q", id)
+	}
+	return adapter, nil
+}
+
+func readFileOrNil(path string) ([]byte, error) {
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	return data, err
+}
+
+// backupSuffix names the sidecar copy of the config as it was before Gateway
+// first wrote to it, so a later "stop managing" step can restore the original.
+const backupSuffix = ".casbin-orig"
+
+// backupOnce saves the pre-Gateway file exactly once. It is a no-op when
+// Gateway is creating the file (nothing to preserve) or when a backup already
+// exists (the current content is Gateway's own, not the user's original).
+func backupOnce(path string, existing []byte) (bool, error) {
+	if existing == nil {
+		return false, nil
+	}
+	backup := path + backupSuffix
+	if _, err := os.Stat(backup); err == nil {
+		return false, nil
+	} else if !os.IsNotExist(err) {
+		return false, err
+	}
+	if err := writeFileAtomic(backup, existing, 0o600); err != nil {
+		return false, err
+	}
+	return true, nil
+}

--- a/agentconfig/switch_test.go
+++ b/agentconfig/switch_test.go
@@ -1,0 +1,105 @@
+// Copyright 2026 The casbin Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agentconfig
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// fakeAdapter renders "provider=<id>\n" into a fixed path, so Switch can be
+// exercised without resolving a real account home.
+type fakeAdapter struct{ path string }
+
+func (fakeAdapter) AgentID() string                      { return "fake" }
+func (f fakeAdapter) ConfigPath(Install) (string, error) { return f.path, nil }
+func (fakeAdapter) DefaultMode() os.FileMode             { return 0o600 }
+func (fakeAdapter) Render(_ []byte, p Provider) ([]byte, error) {
+	return []byte("provider=" + p.ID + "\n"), nil
+}
+
+func registerFake(t *testing.T, path string) {
+	t.Helper()
+	adapters["fake"] = fakeAdapter{path: path}
+	t.Cleanup(func() { delete(adapters, "fake") })
+}
+
+func TestSwitchWritesConfig(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config")
+	registerFake(t, path)
+
+	res, err := Switch(Install{AgentID: "fake"}, Provider{ID: "alpha"})
+	if err != nil {
+		t.Fatalf("Switch: %v", err)
+	}
+	if !res.Changed {
+		t.Error("Changed = false, want true on first write")
+	}
+	if got, _ := os.ReadFile(path); string(got) != "provider=alpha\n" {
+		t.Errorf("config = %q", got)
+	}
+}
+
+func TestSwitchIsIdempotent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config")
+	registerFake(t, path)
+
+	if _, err := Switch(Install{AgentID: "fake"}, Provider{ID: "alpha"}); err != nil {
+		t.Fatalf("first Switch: %v", err)
+	}
+	res, err := Switch(Install{AgentID: "fake"}, Provider{ID: "alpha"})
+	if err != nil {
+		t.Fatalf("second Switch: %v", err)
+	}
+	if res.Changed {
+		t.Error("Changed = true, want false when the provider already matches")
+	}
+}
+
+func TestSwitchBacksUpUserOriginalOnce(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config")
+	registerFake(t, path)
+	if err := os.WriteFile(path, []byte("user original\n"), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	res, err := Switch(Install{AgentID: "fake"}, Provider{ID: "alpha"})
+	if err != nil {
+		t.Fatalf("Switch: %v", err)
+	}
+	if !res.BackedUp {
+		t.Error("BackedUp = false, want true when replacing a user file")
+	}
+	backup := path + backupSuffix
+	if got, _ := os.ReadFile(backup); string(got) != "user original\n" {
+		t.Errorf("backup = %q, want the pre-Gateway original", got)
+	}
+
+	// A second switch must not overwrite the original backup with Gateway's own
+	// content.
+	if _, err := Switch(Install{AgentID: "fake"}, Provider{ID: "beta"}); err != nil {
+		t.Fatalf("second Switch: %v", err)
+	}
+	if got, _ := os.ReadFile(backup); string(got) != "user original\n" {
+		t.Errorf("backup after second switch = %q, want unchanged original", got)
+	}
+}
+
+func TestSwitchUnknownAgent(t *testing.T) {
+	if _, err := Switch(Install{AgentID: "nope"}, Provider{ID: "alpha"}); err == nil {
+		t.Error("expected an error for an unknown agent")
+	}
+}

--- a/agentconfig/tomldoc.go
+++ b/agentconfig/tomldoc.go
@@ -1,0 +1,60 @@
+// Copyright 2026 The casbin Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agentconfig
+
+import (
+	"bytes"
+	"fmt"
+
+	toml "github.com/pelletier/go-toml/v2"
+)
+
+// loadTOML parses a TOML document into a map tree, returning an empty map for an
+// absent or blank file. Unknown tables and keys are preserved on the round trip
+// so an adapter only rewrites the slots it owns.
+//
+// Note: decoding to a map does not retain comments, so a rewrite drops any
+// comments a user placed in the file. Preserving those would require a
+// comment-aware AST, which is out of scope here.
+func loadTOML(existing []byte) (map[string]any, error) {
+	if len(bytes.TrimSpace(existing)) == 0 {
+		return map[string]any{}, nil
+	}
+	var doc map[string]any
+	if err := toml.Unmarshal(existing, &doc); err != nil {
+		return nil, fmt.Errorf("parse config: %w", err)
+	}
+	if doc == nil {
+		return map[string]any{}, nil
+	}
+	return doc, nil
+}
+
+// marshalTOML renders doc back to TOML. go-toml/v2 sorts map keys, so the output
+// is deterministic.
+func marshalTOML(doc map[string]any) ([]byte, error) {
+	return toml.Marshal(doc)
+}
+
+// ensureTOMLTable returns the nested table at key, creating an empty one when it
+// is absent or not a table.
+func ensureTOMLTable(doc map[string]any, key string) map[string]any {
+	if nested, ok := doc[key].(map[string]any); ok {
+		return nested
+	}
+	nested := map[string]any{}
+	doc[key] = nested
+	return nested
+}

--- a/agentpatch/home.go
+++ b/agentpatch/home.go
@@ -27,7 +27,16 @@ import (
 // configuration: an unresolvable owner is an error rather than a fallback to
 // whichever account happens to run Gateway.
 func homeOf(target Target) (string, error) {
-	owner := strings.TrimSpace(target.Owner)
+	return HomeOf(target.Owner)
+}
+
+// HomeOf resolves the home directory of the account named owner (which may be a
+// bare name, DOMAIN\user or user@domain). An empty owner resolves to the account
+// Gateway runs as. It is exported so other packages that write into a user's
+// own configuration resolve the exact directory the monitoring patchers use,
+// rather than reimplementing the cross-platform account lookup.
+func HomeOf(owner string) (string, error) {
+	owner = strings.TrimSpace(owner)
 	if owner == "" {
 		home, err := os.UserHomeDir()
 		if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/lib/pq v1.10.2
 	github.com/likexian/whois v1.15.1
 	github.com/likexian/whois-parser v1.24.9
+	github.com/pelletier/go-toml/v2 v2.1.1
 	github.com/siddontang/go-log v0.0.0-20190221022429-1e957dd83bed
 	github.com/xorm-io/core v0.7.4
 	github.com/xorm-io/xorm v1.1.6

--- a/go.sum
+++ b/go.sum
@@ -1059,6 +1059,8 @@ github.com/onsi/gomega v1.27.8/go.mod h1:2J8vzI/s+2shY9XHRApDkdgPo1TKT7P2u6fXeJK
 github.com/onsi/gomega v1.27.10 h1:naR28SdDFlqrG6kScpT8VWpu1xWY5nJRCF3XaYyBjhI=
 github.com/onsi/gomega v1.27.10/go.mod h1:RsS8tutOdbdgzbPtzzATp12yT7kM5I5aElG3evPbQ0M=
 github.com/pelletier/go-toml v1.0.1/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
+github.com/pelletier/go-toml/v2 v2.1.1 h1:LWAJwfNvjQZCFIDKWYQaM62NcYeYViCmWIwmOStowAI=
+github.com/pelletier/go-toml/v2 v2.1.1/go.mod h1:tJU2Z3ZkXwnxa4DPO899bsyIoywizdUvyaeZurnPPDc=
 github.com/petar-dambovaliev/aho-corasick v0.0.0-20230725210150-fb29fc3c913e h1:POJco99aNgosh92lGqmx7L1ei+kCymivB/419SD15PQ=
 github.com/petar-dambovaliev/aho-corasick v0.0.0-20230725210150-fb29fc3c913e/go.mod h1:EHPiTAKtiFmrMldLUNswFwfZ2eJIYBHktdaUTZxYWRw=
 github.com/peterh/liner v1.0.1-0.20171122030339-3681c2a91233/go.mod h1:xIteQHvHuaLYG9IFj6mSxM0fCKrs34IrEQUhOYuGPHc=


### PR DESCRIPTION
### Summary
Add the config-orchestrator core that switches a CLI agent (Claude Code, Codex) to a chosen upstream provider by writing that provider into the agent's own configuration file. Switch is atomic (temp file + rename, so a crash never leaves a half-written config), idempotent (re-selecting the same provider changes nothing), and non-destructive (only the fields Gateway owns are rewritten; unrelated user settings are preserved, and the pre-Gateway file is backed up once). Each agent's format mapping is a pure adapter, so switching UI, proxy hot-swap and usage stats can build on top separately.
