### PR TITLE
feat: add OpenAI-compatible LLM request audit

### DIFF
--- a/conf/app.conf
+++ b/conf/app.conf
@@ -82,3 +82,11 @@ agentPatchStateDir = "./data/agent-patches"
 agentRecordCapacity = 1000
 ; How often to rescan the append-only logs of file-tailed agents, in seconds.
 agentMonitorPollSeconds = 5
+
+; OpenAI-compatible request audit. When enabled, Gateway stores sanitized
+; request bodies (messages and tool schemas) for the management dashboard.
+; This is deliberately off by default because prompts can contain sensitive data.
+llmRequestAuditEnabled = false
+llmRequestAuditQueueCapacity = 1000
+llmRequestAuditRetentionDays = 30
+llmRequestAuditMaxRecords = 10000

--- a/conf/conf.go
+++ b/conf/conf.go
@@ -225,6 +225,34 @@ func GetAgentMonitorPollSeconds() int {
 	return res
 }
 
+func IsLlmRequestAuditEnabled() bool {
+	return strings.EqualFold(strings.Trim(GetConfigString("llmRequestAuditEnabled"), `"' `), "true")
+}
+
+func GetLlmRequestAuditQueueCapacity() int {
+	capacity := GetConfigIntDefault("llmRequestAuditQueueCapacity", 1000)
+	if capacity <= 0 {
+		return 1000
+	}
+	return capacity
+}
+
+func GetLlmRequestAuditRetentionDays() int {
+	days := GetConfigIntDefault("llmRequestAuditRetentionDays", 30)
+	if days <= 0 {
+		return 30
+	}
+	return days
+}
+
+func GetLlmRequestAuditMaxRecords() int {
+	maximum := GetConfigIntDefault("llmRequestAuditMaxRecords", 10000)
+	if maximum <= 0 {
+		return 10000
+	}
+	return maximum
+}
+
 func GetConfigRealDataSourceName(driverName string) string {
 	var dataSourceName string
 	if driverName != "mysql" {

--- a/controllers/llm_request_audit.go
+++ b/controllers/llm_request_audit.go
@@ -1,0 +1,47 @@
+// Copyright 2026 The casbin Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllers
+
+import (
+	"strconv"
+
+	"github.com/apache/casbin-gateway/object"
+)
+
+// GetLlmRequestAudits returns retained, sanitized model requests. Prompt
+// contents are sensitive operational data, so unlike the public model endpoint
+// this endpoint is always limited to Gateway administrators.
+func (c *ApiController) GetLlmRequestAudits() {
+	if c.RequireAdmin() {
+		return
+	}
+	page, _ := strconv.Atoi(c.Input().Get("page"))
+	if page < 1 {
+		page = 1
+	}
+	limit, _ := strconv.Atoi(c.Input().Get("limit"))
+	if limit < 1 {
+		limit = 50
+	}
+	if limit > 100 {
+		limit = 100
+	}
+	records, count, err := object.GetLlmRequestAudits((page-1)*limit, limit)
+	if err != nil {
+		c.ResponseError(err.Error())
+		return
+	}
+	c.ResponseOk(records, count)
+}

--- a/controllers/proxy.go
+++ b/controllers/proxy.go
@@ -26,8 +26,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/apache/casbin-gateway/conf"
 	"github.com/apache/casbin-gateway/object"
 	"github.com/apache/casbin-gateway/proxy"
+	"github.com/apache/casbin-gateway/util"
 	"github.com/beego/beego"
 )
 
@@ -155,7 +157,7 @@ func (c *ApiController) ChatCompletions() {
 			return
 		}
 
-		status, message, written := c.forwardToChannel(channel, rawBody, req.Stream, i == len(usableChannels)-1)
+		status, message, written := c.forwardToChannel(channel, rawBody, req.Model, req.Stream, i == len(usableChannels)-1)
 		if written {
 			return
 		}
@@ -165,12 +167,19 @@ func (c *ApiController) ChatCompletions() {
 	c.writeOpenAIError(lastStatus, "server_error", lastMessage)
 }
 
+func (c *ApiController) enqueueChatRequestAudit(rawBody []byte, model string, stream bool, channel *object.Channel) {
+	if channel == nil || !conf.IsLlmRequestAuditEnabled() {
+		return
+	}
+	object.EnqueueLlmRequestAudit(rawBody, model, channel.GetId(), util.GetClientIp(c.Ctx.Request), stream)
+}
+
 // forwardToChannel sends the request to a single channel's upstream. It reports
 // whether the client response was already written, and when it was not, the
 // status and message describing the failure so that the caller can fail over to
 // the next channel. The response of the last channel is always relayed, even
 // when its status would otherwise be retried.
-func (c *ApiController) forwardToChannel(channel *object.Channel, rawBody []byte, stream bool, isLast bool) (int, string, bool) {
+func (c *ApiController) forwardToChannel(channel *object.Channel, rawBody []byte, model string, stream bool, isLast bool) (int, string, bool) {
 	upstreamUrl, err := object.BuildOpenAiUrl(channel.BaseUrl, "/chat/completions")
 	if err != nil {
 		return http.StatusBadGateway, err.Error(), false
@@ -203,6 +212,11 @@ func (c *ApiController) forwardToChannel(channel *object.Channel, rawBody []byte
 		return http.StatusBadGateway, "upstream connection failed", false
 	}
 	defer upstreamResp.Body.Close()
+
+	// An HTTP response proves this channel received the request. Recording here
+	// preserves the real channel for each failover attempt without waiting for
+	// disk I/O or transforming the payload on the forwarding goroutine.
+	c.enqueueChatRequestAudit(rawBody, model, stream, channel)
 
 	if !isLast && isRetryableStatus(upstreamResp.StatusCode) {
 		beego.Error("channel", channel.GetId(), "returned a retryable status:", upstreamResp.Status)

--- a/controllers/proxy_test.go
+++ b/controllers/proxy_test.go
@@ -224,7 +224,7 @@ func TestForwardToChannel(t *testing.T) {
 
 	// A retryable status fails over instead of reaching the client.
 	c, recorder := newTestApiController()
-	statusCode, message, written := c.forwardToChannel(overloadedChannel, rawBody, false, false)
+	statusCode, message, written := c.forwardToChannel(overloadedChannel, rawBody, "gpt-4", false, false)
 	if written {
 		t.Fatal("a retryable status was relayed instead of failing over")
 	}
@@ -238,14 +238,14 @@ func TestForwardToChannel(t *testing.T) {
 	// The last channel is relayed as-is, even with a retryable status, so that
 	// the client sees the real upstream answer.
 	c, recorder = newTestApiController()
-	_, _, written = c.forwardToChannel(overloadedChannel, rawBody, false, true)
+	_, _, written = c.forwardToChannel(overloadedChannel, rawBody, "gpt-4", false, true)
 	if !written || recorder.Code != http.StatusServiceUnavailable || !strings.Contains(recorder.Body.String(), "overloaded") {
 		t.Errorf("the last channel was not relayed: written = %v, statusCode = %d, body = %s", written, recorder.Code, recorder.Body.String())
 	}
 
 	// A healthy channel, with a trailing slash in its base URL.
 	c, recorder = newTestApiController()
-	_, _, written = c.forwardToChannel(healthyChannel, rawBody, false, true)
+	_, _, written = c.forwardToChannel(healthyChannel, rawBody, "gpt-4", false, true)
 	if !written || recorder.Code != http.StatusOK || !strings.Contains(recorder.Body.String(), "choices") {
 		t.Errorf("the healthy channel failed: written = %v, statusCode = %d, body = %s", written, recorder.Code, recorder.Body.String())
 	}
@@ -253,7 +253,7 @@ func TestForwardToChannel(t *testing.T) {
 	// stream=true, but the upstream rejected the request: the JSON error must
 	// not be dressed up as an SSE stream.
 	c, recorder = newTestApiController()
-	c.forwardToChannel(overloadedChannel, rawBody, true, true)
+	c.forwardToChannel(overloadedChannel, rawBody, "gpt-4", true, true)
 	if header := recorder.Header().Get("Content-Type"); header != "application/json" {
 		t.Errorf("Content-Type = %s, expected application/json", header)
 	}

--- a/main.go
+++ b/main.go
@@ -45,6 +45,8 @@ func main() {
 	object.InitFlag()
 	object.InitAdapter()
 	object.CreateTables()
+	object.StartLlmRequestAuditWriter()
+	defer object.StopLlmRequestAuditWriter()
 	casdoor.InitCasdoorConfig()
 	object.InitUsers()
 	proxy.InitHttpClient()

--- a/object/llm_request_audit.go
+++ b/object/llm_request_audit.go
@@ -1,0 +1,245 @@
+// Copyright 2026 The casbin Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package object
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"sync"
+	"time"
+
+	"github.com/apache/casbin-gateway/auditutil"
+	"github.com/apache/casbin-gateway/conf"
+	"github.com/apache/casbin-gateway/util"
+	"github.com/beego/beego"
+)
+
+// LlmRequestAudit is a sanitized OpenAI-compatible request snapshot. It is
+// intentionally request-only: response transcript and usage capture belong to
+// a later feature and must not change this proxy's pass-through behaviour.
+type LlmRequestAudit struct {
+	Id            int64  `xorm:"int notnull pk autoincr" json:"id"`
+	CreatedTime   string `xorm:"varchar(100) notnull index" json:"createdTime"`
+	Model         string `xorm:"varchar(255) notnull index" json:"model"`
+	Channel       string `xorm:"varchar(201)" json:"channel"`
+	ClientIp      string `xorm:"varchar(100)" json:"clientIp"`
+	Stream        bool   `xorm:"bool" json:"stream"`
+	Payload       string `xorm:"mediumtext" json:"payload"`
+	Truncated     bool   `xorm:"bool" json:"truncated"`
+	OriginalBytes int    `xorm:"int" json:"originalBytes"`
+}
+
+type llmRequestAuditWriter struct {
+	queue       chan llmRequestAuditTask
+	done        chan struct{}
+	once        sync.Once
+	queueMutex  sync.RWMutex
+	stopped     bool
+	dropMutex   sync.Mutex
+	dropped     uint64
+	lastDropLog time.Time
+}
+
+type llmRequestAuditTask struct {
+	rawBody       []byte
+	model         string
+	channel       string
+	clientIP      string
+	stream        bool
+	originalBytes int
+	bodyOmitted   bool
+}
+
+var requestAuditWriter llmRequestAuditWriter
+
+// StartLlmRequestAuditWriter starts the best-effort persistent writer. It is
+// deliberately opt-in so installations that do not request content retention
+// neither retain prompts nor pay any proxy-path cost.
+func StartLlmRequestAuditWriter() {
+	if !conf.IsLlmRequestAuditEnabled() {
+		return
+	}
+	requestAuditWriter.once.Do(func() {
+		requestAuditWriter.queue = make(chan llmRequestAuditTask, conf.GetLlmRequestAuditQueueCapacity())
+		requestAuditWriter.done = make(chan struct{})
+		go requestAuditWriter.run()
+	})
+}
+
+// StopLlmRequestAuditWriter drains accepted entries during graceful shutdown.
+func StopLlmRequestAuditWriter() {
+	requestAuditWriter.queueMutex.Lock()
+	if requestAuditWriter.queue == nil || requestAuditWriter.stopped {
+		requestAuditWriter.queueMutex.Unlock()
+		return
+	}
+	queue, done := requestAuditWriter.queue, requestAuditWriter.done
+	requestAuditWriter.stopped = true
+	close(queue)
+	requestAuditWriter.queueMutex.Unlock()
+	<-done
+}
+
+// EnqueueLlmRequestAudit never parses, sanitizes, or writes the request on the
+// proxy goroutine. Oversized bodies are represented by safe metadata so the
+// bounded queue cannot retain arbitrary amounts of request memory.
+func EnqueueLlmRequestAudit(rawBody []byte, model, channel, clientIP string, stream bool) {
+	task := llmRequestAuditTask{
+		rawBody: rawBody, model: model, channel: channel, clientIP: clientIP, stream: stream,
+		originalBytes: len(rawBody),
+	}
+	if len(rawBody) > auditutil.MaxPayloadBytes {
+		task.rawBody, task.bodyOmitted = nil, true
+	}
+	requestAuditWriter.queueMutex.RLock()
+	defer requestAuditWriter.queueMutex.RUnlock()
+	if requestAuditWriter.queue == nil || requestAuditWriter.stopped {
+		return
+	}
+	select {
+	case requestAuditWriter.queue <- task:
+	default:
+		requestAuditWriter.noteDrop()
+	}
+}
+
+func (writer *llmRequestAuditWriter) noteDrop() {
+	writer.dropMutex.Lock()
+	defer writer.dropMutex.Unlock()
+	writer.dropped++
+	if time.Since(writer.lastDropLog) < time.Minute {
+		return
+	}
+	beego.Error("LLM request audit queue is full; dropped audit records:", writer.dropped)
+	writer.lastDropLog = time.Now()
+	writer.dropped = 0
+}
+
+func (writer *llmRequestAuditWriter) run() {
+	defer close(writer.done)
+	writer.prune()
+	ticker := time.NewTicker(time.Minute)
+	defer ticker.Stop()
+	for {
+		select {
+		case task, ok := <-writer.queue:
+			if !ok {
+				return
+			}
+			record := task.record()
+			if record == nil {
+				beego.Error("LLM request audit serialization failed")
+				continue
+			}
+			if _, err := ormer.Engine.Insert(record); err != nil {
+				beego.Error("LLM request audit write failed:", err)
+			}
+		case <-ticker.C:
+			writer.prune()
+		}
+	}
+}
+
+func (writer *llmRequestAuditWriter) prune() {
+	if ormer == nil || ormer.Engine == nil {
+		return
+	}
+	cutoff := util.FormatTime(time.Now().AddDate(0, 0, -conf.GetLlmRequestAuditRetentionDays()))
+	if _, err := ormer.Engine.Where("created_time < ?", cutoff).Delete(&LlmRequestAudit{}); err != nil {
+		beego.Error("LLM request audit retention cleanup failed:", err)
+		return
+	}
+
+	count, err := ormer.Engine.Count(&LlmRequestAudit{})
+	if err != nil {
+		beego.Error("LLM request audit retention count failed:", err)
+		return
+	}
+	if count <= int64(conf.GetLlmRequestAuditMaxRecords()) {
+		return
+	}
+	excess := int(count) - conf.GetLlmRequestAuditMaxRecords()
+	oldest := make([]LlmRequestAudit, 0, excess)
+	if err := ormer.Engine.Asc("id").Limit(excess).Find(&oldest); err != nil {
+		beego.Error("LLM request audit retention lookup failed:", err)
+		return
+	}
+	ids := make([]int64, 0, len(oldest))
+	for _, record := range oldest {
+		ids = append(ids, record.Id)
+	}
+	if len(ids) > 0 {
+		if _, err := ormer.Engine.In("id", ids).Delete(&LlmRequestAudit{}); err != nil {
+			beego.Error("LLM request audit retention deletion failed:", err)
+		}
+	}
+}
+
+func (task llmRequestAuditTask) record() *LlmRequestAudit {
+	if task.bodyOmitted {
+		return &LlmRequestAudit{
+			CreatedTime: util.GetCurrentTime(), Model: task.model, Channel: task.channel, ClientIp: task.clientIP,
+			Stream: task.stream, Truncated: true, OriginalBytes: task.originalBytes,
+			Payload: auditutil.EncodeBoundedJSON(map[string]any{
+				"truncated": true, "originalBytes": task.originalBytes,
+				"reason": "request body exceeds the audit capture limit",
+			}, auditutil.MaxPayloadBytes),
+		}
+	}
+	return NewLlmRequestAudit(task.rawBody, task.model, task.channel, task.clientIP, task.stream)
+}
+
+// NewLlmRequestAudit sanitizes a queued request body on the writer goroutine.
+// This is the sole body-retention boundary: headers, especially inbound
+// authorization credentials, are never copied into an audit record.
+func NewLlmRequestAudit(rawBody []byte, model, channel, clientIP string, stream bool) *LlmRequestAudit {
+	var decoded any
+	decoder := json.NewDecoder(bytes.NewReader(rawBody))
+	decoder.UseNumber()
+	if decoder.Decode(&decoded) != nil {
+		return nil
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		return nil
+	}
+	sanitized := auditutil.SanitizeValue("", decoded)
+	encoded, err := json.Marshal(sanitized)
+	if err != nil {
+		return nil
+	}
+	record := &LlmRequestAudit{
+		CreatedTime: util.GetCurrentTime(), Model: model, Channel: channel, ClientIp: clientIP,
+		Stream: stream, OriginalBytes: len(rawBody),
+	}
+	if len(encoded) <= auditutil.MaxPayloadBytes {
+		record.Payload = string(encoded)
+		return record
+	}
+	record.Truncated = true
+	record.Payload = auditutil.EncodeBoundedJSON(sanitized, auditutil.MaxPayloadBytes)
+	return record
+}
+
+func GetLlmRequestAudits(offset, limit int) ([]*LlmRequestAudit, int64, error) {
+	records := []*LlmRequestAudit{}
+	count, err := ormer.Engine.Count(&LlmRequestAudit{})
+	if err != nil {
+		return nil, 0, err
+	}
+	err = ormer.Engine.Desc("id").Limit(limit, offset).Find(&records)
+	return records, count, err
+}

--- a/object/llm_request_audit_test.go
+++ b/object/llm_request_audit_test.go
@@ -1,0 +1,101 @@
+// Copyright 2026 The casbin Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package object
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/apache/casbin-gateway/auditutil"
+)
+
+func TestNewLlmRequestAuditCapturesOpenAICompatibleRequest(t *testing.T) {
+	raw := []byte(`{
+		"model":"gpt-test",
+		"stream":true,
+		"messages":[
+			{"role":"system","content":"You are a helpful assistant."},
+			{"role":"user","content":"Hello"}
+		],
+		"tools":[{"type":"function","function":{"name":"weather","parameters":{"type":"object","properties":{"city":{"type":"string"}}}}}],
+		"tool_choice":"auto"
+	}`)
+	record := NewLlmRequestAudit(raw, "gpt-test", "admin/default", "127.0.0.1", true)
+	if record == nil {
+		t.Fatal("request audit was not created")
+	}
+	if !record.Stream || record.Model != "gpt-test" || record.Channel != "admin/default" || record.ClientIp != "127.0.0.1" {
+		t.Errorf("metadata = %#v", record)
+	}
+	if record.OriginalBytes != len(raw) {
+		t.Errorf("originalBytes = %d, expected raw body length %d", record.OriginalBytes, len(raw))
+	}
+	for _, expected := range []string{"You are a helpful assistant.", "Hello", "weather", "tool_choice"} {
+		if !strings.Contains(record.Payload, expected) {
+			t.Errorf("payload did not preserve %q: %s", expected, record.Payload)
+		}
+	}
+}
+
+func TestLlmRequestAuditTaskOmitsOversizedRawBody(t *testing.T) {
+	task := llmRequestAuditTask{
+		model: "gpt-test", channel: "admin/default", clientIP: "127.0.0.1", originalBytes: auditutil.MaxPayloadBytes + 1,
+		bodyOmitted: true,
+	}
+	record := task.record()
+	if record == nil || !record.Truncated || record.OriginalBytes != auditutil.MaxPayloadBytes+1 {
+		t.Errorf("unexpected oversized task record: %#v", record)
+	}
+	if strings.Contains(record.Payload, "rawBody") || !strings.Contains(record.Payload, "capture limit") {
+		t.Errorf("oversized task payload was not safe metadata: %s", record.Payload)
+	}
+}
+
+func TestNewLlmRequestAuditRedactsCredentials(t *testing.T) {
+	record := NewLlmRequestAudit([]byte(`{
+		"model":"gpt-test","messages":[{"role":"user","content":"Bearer sk-abcdefghijklmnopqrstuvwxyz"}],
+		"tools":[{"type":"function","function":{"name":"x","parameters":{"api_key":"top-secret","nested":{"authorization":"secret"}}}}]
+	}`), "gpt-test", "admin/default", "127.0.0.1", false)
+	if record == nil {
+		t.Fatal("request audit was not created")
+	}
+	if strings.Contains(record.Payload, "top-secret") || strings.Contains(record.Payload, "abcdefghijklmnopqrstuvwxyz") || strings.Contains(record.Payload, `"authorization":"secret"`) {
+		t.Errorf("credential was retained: %s", record.Payload)
+	}
+	if !strings.Contains(record.Payload, "[REDACTED]") {
+		t.Errorf("sanitized payload has no redaction marker: %s", record.Payload)
+	}
+}
+
+func TestNewLlmRequestAuditBoundsOversizedPayload(t *testing.T) {
+	raw, err := json.Marshal(map[string]any{
+		"model":    "gpt-test",
+		"messages": []map[string]string{{"role": "system", "content": strings.Repeat("x", auditutil.MaxPayloadBytes*2)}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	record := NewLlmRequestAudit(raw, "gpt-test", "admin/default", "127.0.0.1", false)
+	if record == nil || !record.Truncated || record.OriginalBytes <= auditutil.MaxPayloadBytes || len(record.Payload) > auditutil.MaxPayloadBytes {
+		t.Errorf("unexpected bounded record: %#v", record)
+	}
+}
+
+func TestNewLlmRequestAuditRejectsInvalidJSON(t *testing.T) {
+	if record := NewLlmRequestAudit([]byte(`{"model":`), "gpt-test", "admin/default", "127.0.0.1", false); record != nil {
+		t.Errorf("invalid JSON created an audit record: %#v", record)
+	}
+}

--- a/object/ormer.go
+++ b/object/ormer.go
@@ -282,4 +282,9 @@ func (a *Ormer) createTable() {
 	if err != nil {
 		panic(err)
 	}
+
+	err = a.Engine.Sync2(new(LlmRequestAudit))
+	if err != nil {
+		panic(err)
+	}
 }

--- a/routers/router.go
+++ b/routers/router.go
@@ -92,6 +92,7 @@ func initAPI() {
 	beego.Router("/api/update-channel", &controllers.ApiController{}, "POST:UpdateChannel")
 	beego.Router("/api/delete-channel", &controllers.ApiController{}, "POST:DeleteChannel")
 	beego.Router("/api/test-channel", &controllers.ApiController{}, "POST:TestChannel")
+	beego.Router("/api/get-llm-request-audits", &controllers.ApiController{}, "GET:GetLlmRequestAudits")
 
 	// OpenAI-compatible chat completions endpoint for LLM gateway milestone 1.2.
 	beego.Router("/v1/chat/completions", &controllers.ApiController{}, "POST:ChatCompletions")

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -34,6 +34,7 @@ import CertEditPage from "@/pages/CertEditPage";
 import CertListPage from "@/pages/CertListPage";
 import ChannelEditPage from "@/pages/ChannelEditPage";
 import ChannelListPage from "@/pages/ChannelListPage";
+import LlmRequestAuditsPage from "@/pages/LlmRequestAuditsPage";
 import NodeEditPage from "@/pages/NodeEditPage";
 import NodeListPage from "@/pages/NodeListPage";
 import RecordEditPage from "@/pages/RecordEditPage";
@@ -207,6 +208,10 @@ export default function App() {
                 <Route
                   path="/channels/:owner/:channelName"
                   element={requireSignin(() => <ChannelEditPage />)}
+                />
+                <Route
+                  path="/llm-request-audits"
+                  element={requireSignin(user => <LlmRequestAuditsPage account={user} />)}
                 />
                 <Route path="/dashboard" element={requireSignin(() => <DashboardPage />)} />
               </Routes>

--- a/web/src/backend/LlmRequestAuditBackend.ts
+++ b/web/src/backend/LlmRequestAuditBackend.ts
@@ -1,0 +1,22 @@
+// Copyright 2026 The casbin Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {query, request} from "@/backend/request";
+import type {LlmRequestAudit} from "@/types";
+
+export function getLlmRequestAudits(page = 1, limit = 50) {
+  return request<LlmRequestAudit[], number>(
+    `/api/get-llm-request-audits${query({page, limit})}`,
+  );
+}

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -67,6 +67,7 @@ function getMainEntries(): MenuEntry[] {
       adminOnly: true,
     },
     {key: "/channels", label: i18next.t("channel:Channels"), icon: <Plug />},
+    {key: "/llm-request-audits", label: i18next.t("llm:Request Audits"), icon: <FileSearch />, adminOnly: true},
   ];
 }
 

--- a/web/src/locales/en/data.json
+++ b/web/src/locales/en/data.json
@@ -189,6 +189,17 @@
   "node": {
     "Edit Node": "Edit Node"
   },
+  "llm": {
+    "Channel": "Channel",
+    "Complete": "Complete",
+    "Failed to get request audits": "Failed to get request audits",
+    "Mode": "Mode",
+    "No request audits yet": "No request audits yet — enable llmRequestAuditEnabled and send a request through the LLM gateway.",
+    "Request Audits": "LLM Request Audits",
+    "Request audit notice": "Only sanitized model requests sent through Gateway are retained. Responses are not captured by this feature.",
+    "Stored": "Stored",
+    "Truncated": "Truncated"
+  },
   "rule": {
     "Allow": "Allow",
     "Block": "Block",

--- a/web/src/locales/zh/data.json
+++ b/web/src/locales/zh/data.json
@@ -189,6 +189,17 @@
   "node": {
     "Edit Node": "Edit Node"
   },
+  "llm": {
+    "Channel": "渠道",
+    "Complete": "完整",
+    "Failed to get request audits": "获取请求审计失败",
+    "Mode": "模式",
+    "No request audits yet": "暂无请求审计记录——请启用 llmRequestAuditEnabled，并通过 LLM 网关发送请求。",
+    "Request Audits": "LLM 请求审计",
+    "Request audit notice": "仅保留经由 Gateway 发送的、已脱敏的模型请求；本功能不采集模型响应。",
+    "Stored": "保存状态",
+    "Truncated": "已截断"
+  },
   "rule": {
     "Allow": "允许",
     "Block": "阻止",

--- a/web/src/pages/LlmRequestAuditsPage.tsx
+++ b/web/src/pages/LlmRequestAuditsPage.tsx
@@ -1,0 +1,124 @@
+// Copyright 2026 The casbin Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as React from "react";
+import {CircleX, Info, RefreshCw} from "lucide-react";
+import i18next from "i18next";
+
+import * as LlmRequestAuditBackend from "@/backend/LlmRequestAuditBackend";
+import * as Setting from "@/Setting";
+import {DataTable, type Column} from "@/components/DataTable";
+import {PageHeader} from "@/components/FormRow";
+import {UnauthorizedResult} from "@/components/Result";
+import {Alert, AlertDescription} from "@/components/ui/alert";
+import {Badge} from "@/components/ui/badge";
+import {Button} from "@/components/ui/button";
+import {Switch} from "@/components/ui/switch";
+import type {Account, LlmRequestAudit} from "@/types";
+
+function formatJSON(value: string) {
+  try {
+    return JSON.stringify(JSON.parse(value), null, 2);
+  } catch {
+    return value;
+  }
+}
+
+export default function LlmRequestAuditsPage({account}: {account: Account}) {
+  const isAdmin = Setting.isAdminUser(account);
+  const [records, setRecords] = React.useState<LlmRequestAudit[]>([]);
+  const [total, setTotal] = React.useState(0);
+  const [page, setPage] = React.useState(1);
+  const [pageSize, setPageSize] = React.useState(50);
+  const [loading, setLoading] = React.useState(false);
+  const [error, setError] = React.useState("");
+  const [autoRefresh, setAutoRefresh] = React.useState(true);
+
+  const load = React.useCallback((foreground = true) => {
+    if (!isAdmin) {
+      return;
+    }
+    if (foreground) {
+      setLoading(true);
+    }
+    LlmRequestAuditBackend.getLlmRequestAudits(page, pageSize)
+      .then(res => {
+        if (res.status === "ok") {
+          setRecords(res.data ?? []);
+          setTotal(res.data2 ?? 0);
+          setError("");
+        } else {
+          setError(res.msg || i18next.t("llm:Failed to get request audits"));
+        }
+      })
+      .catch(err => setError(err.message || String(err)))
+      .finally(() => foreground && setLoading(false));
+  }, [isAdmin, page, pageSize]);
+
+  React.useEffect(() => {
+    if (!isAdmin) {
+      return undefined;
+    }
+    load(true);
+    if (!autoRefresh) {
+      return undefined;
+    }
+    const interval = setInterval(() => load(false), 3000);
+    return () => clearInterval(interval);
+  }, [autoRefresh, isAdmin, load]);
+
+  if (!isAdmin) {
+    return <UnauthorizedResult />;
+  }
+
+  const columns: Column<LlmRequestAudit>[] = [
+    {title: i18next.t("agent:Time"), key: "createdTime", dataIndex: "createdTime", width: "180px", render: value => new Date(value).toLocaleString()},
+    {title: i18next.t("agent:Model"), key: "model", dataIndex: "model", width: "180px", render: value => <code className="text-xs">{value}</code>},
+    {title: i18next.t("llm:Channel"), key: "channel", dataIndex: "channel", width: "180px", render: value => <code className="text-xs">{value}</code>},
+    {title: i18next.t("general:Client IP"), key: "clientIp", dataIndex: "clientIp", width: "145px"},
+    {title: i18next.t("llm:Mode"), key: "stream", dataIndex: "stream", width: "110px", render: value => <Badge variant="secondary">{value ? "SSE" : "JSON"}</Badge>},
+    {title: i18next.t("llm:Stored"), key: "payload", width: "130px", render: (_value, record) => record.truncated ? <Badge variant="warning">{i18next.t("llm:Truncated")}</Badge> : <Badge variant="success">{i18next.t("llm:Complete")}</Badge>},
+  ];
+
+  return (
+    <div className="p-4 md:p-6">
+      <PageHeader title={i18next.t("llm:Request Audits")}>
+        <label className="flex items-center gap-2 text-sm">
+          <Switch checked={autoRefresh} onCheckedChange={setAutoRefresh} />
+          {i18next.t("agent:Auto refresh")}
+        </label>
+        <Button variant="outline" onClick={() => load(true)} disabled={loading}>
+          <RefreshCw className={loading ? "animate-spin" : undefined} />
+          {i18next.t("general:Refresh")}
+        </Button>
+      </PageHeader>
+      <Alert variant="info" className="mb-4">
+        <Info />
+        <AlertDescription>{i18next.t("llm:Request audit notice")}</AlertDescription>
+      </Alert>
+      {error && <Alert variant="destructive" className="mb-4"><CircleX /><AlertDescription>{error}</AlertDescription></Alert>}
+      <DataTable
+        columns={columns}
+        data={records}
+        rowKey={record => String(record.id)}
+        loading={loading}
+        emptyText={i18next.t("llm:No request audits yet")}
+        expandedRowRender={record => (
+          <pre className="max-h-[32rem] overflow-auto whitespace-pre-wrap break-all p-4 font-mono text-xs">{formatJSON(record.payload)}</pre>
+        )}
+        serverPagination={{page, pageSize, total, onChange: (nextPage, nextSize) => { setPage(nextPage); setPageSize(nextSize); }}}
+      />
+    </div>
+  );
+}

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -207,6 +207,18 @@ export interface AgentSession {
   lastTime: string;
 }
 
+export interface LlmRequestAudit {
+  id: number;
+  createdTime: string;
+  model: string;
+  channel: string;
+  clientIp: string;
+  stream: boolean;
+  payload: string;
+  truncated: boolean;
+  originalBytes: number;
+}
+
 export interface MetricPoint {
   data: string;
   count: number;


### PR DESCRIPTION
## Why

The gateway is the single choke point for /v1/chat/completions traffic, but operators have no visibility into what models are actually being asked to do. Debugging prompt injection, abuse, or unexpected model usage today means tapping every upstream or grepping logs that never capture request bodies. Prompt content is sensitive operational data, so any retention must be opt-in, sanitized, and strictly bounded.

## What changed

Gateway can now record sanitized chat-completions requests in a new llm\_request\_audit table, viewable by administrators in the management UI.

### Backend:

- object/llm\_request\_audit.go: new table (id, createdTime, model, channel, clientIp, stream, payload, truncated, originalBytes), created via Sync2 on startup.
- Best-effort async writer with a bounded queue: the proxy goroutine only enqueues a metadata snapshot and never parses, sanitizes, or writes; a full queue drops records and logs the drop count at most once a minute; graceful shutdown drains accepted entries.
- Sanitization runs only on the writer goroutine — the sole body-retention boundary. Headers (especially inbound authorization) are never copied into a record. Credential-bearing fields and embedded secrets are redacted via auditutil.SanitizeValue; bodies larger than 64 KiB are stored as safe metadata (truncated, originalBytes) instead of raw bytes.
- Retention is bounded by age (llmRequestAuditRetentionDays) and count (llmRequestAuditMaxRecords), pruned once a minute.
- controllers/proxy.go: forwardToChannel records an entry only after the upstream responds, so each failover attempt keeps its real channel.
- New admin-only, paginated endpoint GET /api/get-llm-request-audits.
- conf/conf.go + conf/app.conf: llmRequestAuditEnabled (opt-in; disabled installs retain nothing and pay no proxy-path cost), llmRequestAuditQueueCapacity, llmRequestAuditRetentionDays, llmRequestAuditMaxRecords.
  Frontend:

New admin-only "LLM Request Audits" page (web/src/pages/LlmRequestAuditsPage.tsx) with pagination and a table of channel / model / mode / client IP / stored / truncated; full i18n (en + zh); route and sidebar entry added.

## Verification

- go test ./object -run TestLlmRequestAudit -v: covers sanitization, credential redaction, oversized-body metadata, and invalid-JSON rejection.
- go test ./controllers ./object: passes, including the updated forwardToChannel tests.
- go build ./...: clean.
- Manual: enable llmRequestAuditEnabled \= true, send requests through /v1/chat/completions, confirm records appear in the admin page, embedded credentials in messages/tools are redacted, oversized requests are truncated, and entries beyond the retention window are pruned.