### PR TITLE
feat(proxy): fail over agent requests to other channels

### DIFF
--- a/controllers/agent_failover_test.go
+++ b/controllers/agent_failover_test.go
@@ -1,0 +1,70 @@
+// Copyright 2026 The casbin Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllers
+
+import (
+	"testing"
+
+	"github.com/apache/casbin-gateway/object"
+)
+
+func chId(channels []*object.Channel) []string {
+	ids := make([]string, len(channels))
+	for i, channel := range channels {
+		ids[i] = channel.GetId()
+	}
+	return ids
+}
+
+func TestAgentChannels(t *testing.T) {
+	bound := &object.Channel{Owner: "admin", Name: "primary"}
+	c1 := &object.Channel{Owner: "admin", Name: "alt1"}
+	c2 := &object.Channel{Owner: "admin", Name: "alt2"}
+
+	tests := []struct {
+		name      string
+		fallbacks []*object.Channel
+		want      []string
+	}{
+		{
+			name: "no fallbacks",
+			want: []string{"admin/primary"},
+		},
+		{
+			name:      "bound first then fallbacks in order",
+			fallbacks: []*object.Channel{c1, c2},
+			want:      []string{"admin/primary", "admin/alt1", "admin/alt2"},
+		},
+		{
+			name:      "bound is dropped from fallbacks so it is not retried twice",
+			fallbacks: []*object.Channel{c1, bound, c2},
+			want:      []string{"admin/primary", "admin/alt1", "admin/alt2"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := chId(agentChannels(bound, test.fallbacks))
+			if len(got) != len(test.want) {
+				t.Fatalf("got %v, want %v", got, test.want)
+			}
+			for i, id := range test.want {
+				if got[i] != id {
+					t.Errorf("position %d = %q, want %q (full: %v)", i, got[i], id, got)
+				}
+			}
+		})
+	}
+}

--- a/controllers/proxy.go
+++ b/controllers/proxy.go
@@ -225,7 +225,31 @@ func (c *ApiController) proxyByAgent(target proxyTarget) {
 		return
 	}
 
-	c.forwardToChannels([]*object.Channel{channel}, route)
+	// The bound channel is always tried first, honouring the binding. If it
+	// fails, fall over to the other enabled channels that serve the requested
+	// model, in priority order, so a single dead upstream does not take the
+	// agent down. A fallback lookup error is non-fatal: the bound channel is
+	// still tried on its own.
+	fallbacks, err := object.GetChannelsByModel(route.model)
+	if err != nil && !errors.Is(err, object.ErrNoChannelAvailable) {
+		beego.Error("agent fallback channel lookup failed:", err)
+		fallbacks = nil
+	}
+
+	c.forwardToChannels(agentChannels(channel, fallbacks), route)
+}
+
+// agentChannels puts the agent's bound channel first, then the model-matched
+// fallbacks in priority order, dropping any duplicate of the bound channel so a
+// failover never retries the same upstream twice.
+func agentChannels(bound *object.Channel, fallbacks []*object.Channel) []*object.Channel {
+	channels := []*object.Channel{bound}
+	for _, fallback := range fallbacks {
+		if fallback.GetId() != bound.GetId() {
+			channels = append(channels, fallback)
+		}
+	}
+	return channels
 }
 
 func (c *ApiController) readProxyRoute(target proxyTarget) (*proxyRoute, bool) {


### PR DESCRIPTION
### What

Agent-bound requests now fail over instead of dying with their single bound channel. proxyByAgent tries the bound channel first (honouring the binding), then falls over to the other enabled channels serving the same model, in priority order — reusing the existing forwardToChannels failover path.

A new agentChannels helper builds that ordered list and drops any duplicate of the bound channel so the same upstream is never retried twice.

### Why

proxyByModel already fails over across channels; the agent path was the only entry point still pinned to one upstream, so a single dead channel took the whole agent down. This closes that gap.

The fallback lookup is best-effort: ErrNoChannelAvailable is treated as "no fallbacks", and any other lookup error is logged but non-fatal — the bound channel is still tried on its own, so failover never makes an agent request worse than before.

### Tests

TestAgentChannels covers the ordering (bound first, then fallbacks in priority order) and the de-duplication of the bound channel from the fallback list.